### PR TITLE
Better output for where command when no Pipfile

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -64,7 +64,9 @@ def do_where(virtualenv=False, bare=True):
     if not virtualenv:
         location = project.pipfile_location
 
-        if not bare:
+        if not location:
+            click.echo('No Pipfile present at project home. Consider running {0} first to automatically generate a Pipfile for you.'.format(crayons.green('`pipenv install`')))
+        elif not bare:
             click.echo('Pipfile found at {0}. Considering this to be the project home.'.format(crayons.green(location)))
         else:
             click.echo(location)


### PR DESCRIPTION
Presently when there is no Pipfile inside a directory, running
`pip --where` gives
`Pipfile found at None. Considering this to be the project home.`.
This seems ambiguous and I've changed it to
```
$ pipenv --where
No Pipfile present at project home. Consider running `pipenv install`
first to automatically generate a Pipfile for you.
$
```