### PR TITLE
Fixes terminal size not being set properly

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -3,6 +3,10 @@ import json
 import os
 import sys
 import distutils.spawn
+if sys.version_info < (3, 3):
+    from backports.shutil_get_terminal_size import shutil_get_terminal_size
+else:
+    from shutil import get_terminal_size as shutil_get_terminal_size
 import shutil
 import signal
 
@@ -424,7 +428,7 @@ def shell():
 
     # Grab current terminal dimensions to replace the hardcoded default
     # dimensions of pexpect
-    terminal_dimensions = shutil.get_terminal_size()
+    terminal_dimensions = shutil_get_terminal_size()
 
     c = pexpect.spawn(
             "{0} -c '. {1}; exec {0} -i'".format(
@@ -444,7 +448,7 @@ def shell():
     # Must be defined here to have the shell process in its context, since we
     # can't pass it as an argument
     def sigwinch_passthrough(sig, data):
-        terminal_dimensions = shutil.get_terminal_size()
+        terminal_dimensions = shutil_get_terminal_size()
         c.setwinsize(terminal_dimensions.lines, terminal_dimensions.columns)
     signal.signal(signal.SIGWINCH, sigwinch_passthrough)
 


### PR DESCRIPTION
See at http://pexpect.sourceforge.net/pexpect.html the documentation
of interact. I include here for easy reference

  | Note that if you change the window size of the parent the SIGWINCH
  | signal will not be passed through to the child.