### PR TITLE
Return subprocess exit code

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -563,6 +563,8 @@ def shell(three=None):
 
     # Interact with the new shell.
     c.interact()
+    c.close()
+    sys.exit(c.exitstatus)
 
 
 @click.command(help="Spawns a command installed into the virtualenv.", context_settings=dict(
@@ -585,6 +587,8 @@ def run(command, args, three=None):
 
     # Interact with the new shell.
     c.interact()
+    c.close()
+    sys.exit(c.exitstatus)
 
 
 @click.command(help="Checks PEP 508 markers provided in Pipfile.")


### PR DESCRIPTION
So, pulling the thread a bit more on kennethreitz/requests#3830, it appears Travis tests will *always* pass, regardless of failures, when run via `pipenv run`. It appears the problem is that pipenv isn't checking the exit code on the subprocess, so it always returns 0 from a successful execution of `cli.py`. This patch will allow pipenv to properly return whether or not a task succeeded to the shell.

There may be a better way to do this, but this was all I could find in the `pexpect` documentation. I used Requests' Travis build to test this and it behaves as expected with the patch. I can look into mocking up a few tests, but I wasn't sure how they would fit in with the current testing setup.

Sorry to be bombarding you with PRs today :)