### PR TITLE
pass unicode to parser instead of bytes

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -418,7 +418,7 @@ def proper_case(package_name):
 
     # Parse the HTML.
     parser = SimpleHTMLParser()
-    parser.feed(r.content)
+    parser.feed(r.text)
 
     # Use the last link on the page, use it to get proper casing.
     return parse_download_fname(collected[-1])[0]


### PR DESCRIPTION
Quick fix for #88, passing `str`/`unicode` instead of `bytes` to the parser because Python 3 can't process `bytes`.

I chose Requests' `text` property instead of `decode('utf-8')` in the event we get an unexpected page encoding, but that may be overkill. There isn't a significant increase in overhead using this since `chardet` is already being loaded with Requests, and we're parsing the whole page.