### PR TITLE
handle bad package names more gracefully

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -415,6 +415,8 @@ def proper_case(package_name):
 
     # Hit the simple API.
     r = requests.get('{0}/{1}'.format(project.source['url'], package_name))
+    if not r.ok:
+        raise IOError('Unable to find package {0} in PyPI repository.'.format(crayons.green(package_name)))
 
     # Parse the HTML.
     parser = SimpleHTMLParser()
@@ -528,7 +530,11 @@ def install(package_name=False, more_packages=False, dev=False, three=False, sys
 
         # Proper-case incoming package name (check against API).
         old_name = [k for k in convert_deps_from_pip(package_name).keys()][0]
-        new_name = proper_case(old_name)
+        try:
+            new_name = proper_case(old_name)
+        except IOError as e:
+            click.echo('{0} {1}'.format(crayons.red('Error: '), e.args[0], crayons.green(package_name)))
+            continue
         package_name = package_name.replace(old_name, new_name)
 
         click.echo('Installing {0}...'.format(crayons.green(package_name)))


### PR DESCRIPTION
This addresses an issue of trying to install bad package names which is tangential to, but possibly not completely covering, #95. I'm not sure if you'd like this to be resilient or hit a hard stop if it encounters a package it can't find.

Current repro:

```bash
>>> pipenv install notreal
Traceback (most recent call last):
  File "/Users/a/Work/OpenSource/sauna-test/.venv/bin/pipenv", line 11, in <module>
    load_entry_point('pipenv==3.1.9', 'console_scripts', 'pipenv')()
  File "/Users/a/Work/OpenSource/sauna-test/.venv/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/a/Work/OpenSource/sauna-test/.venv/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/a/Work/OpenSource/sauna-test/.venv/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/a/Work/OpenSource/sauna-test/.venv/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/a/Work/OpenSource/sauna-test/.venv/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/a/Work/OpenSource/sauna-test/.venv/lib/python3.6/site-packages/pipenv-3.1.9-py3.6.egg/pipenv/cli.py", line 533, in install
    new_name = proper_case(old_name)
  File "/Users/a/Work/OpenSource/sauna-test/.venv/lib/python3.6/site-packages/pipenv-3.1.9-py3.6.egg/pipenv/cli.py", line 425, in proper_case
    return parse_download_fname(collected[-1])[0]
  File "/Users/a/Work/OpenSource/sauna-test/.venv/lib/python3.6/site-packages/pipenv-3.1.9-py3.6.egg/pipenv/cli.py", line 219, in parse_download_fname
    name = r['name']
TypeError: 'NoneType' object is not subscriptable
```