### PR TITLE
Use list of arguments in calls to `pexpect.spawn`

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -700,9 +700,8 @@ def shell(three=None):
     terminal_dimensions = get_terminal_size()
 
     c = pexpect.spawn(
-            "{0} -i'".format(
-                shell
-            ),
+            shell,
+            ["-i"],
             dimensions=(
                 terminal_dimensions.lines,
                 terminal_dimensions.columns
@@ -739,7 +738,7 @@ def run(command, args, three=None):
 
     # Spawn the new process, and interact with it.
     try:
-        c = pexpect.spawn('{0} {1}'.format(which(command), ' '.join(args)))
+        c = pexpect.spawn(which(command), args)
     except pexpect.exceptions.ExceptionPexpect:
         click.echo(crayons.red('The command was not found within the virtualenv!'))
         sys.exit(1)

--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -738,7 +738,7 @@ def run(command, args, three=None):
 
     # Spawn the new process, and interact with it.
     try:
-        c = pexpect.spawn(which(command), args)
+        c = pexpect.spawn(which(command), list(args))
     except pexpect.exceptions.ExceptionPexpect:
         click.echo(crayons.red('The command was not found within the virtualenv!'))
         sys.exit(1)


### PR DESCRIPTION
This PR fixes #81 by using a list of arguments for calls to `pexpect.spawn` instead of a formateed string.

Cheers