### PR TITLE
update error message for missing SHELL variable

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -690,7 +690,9 @@ def shell(three=None):
     try:
         shell = os.environ['SHELL']
     except KeyError:
-        click.echo(crayons.red('Windows is not currently supported.'))
+        error = ('No shell found: Please ensure the SHELL environment variable is set. '
+                 'Windows is not currently supported.')
+        click.echo(crayons.red(error))
         sys.exit(1)
 
     click.echo(crayons.yellow('Spawning environment shell ({0}).'.format(crayons.red(shell))))


### PR DESCRIPTION
This is a clarifies the error message when `$SHELL` isn't found. Certain linux environments (Alpine as shown in #104) don't have the variable set automatically, so we can let the user know they need to set it in that case.