### PR TITLE
fixing OrderedDict

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -102,7 +102,7 @@ def ensure_proper_casing():
         casing_changed = False
 
         if section in p:
-            old_keys = []
+            changed_values = []
 
             # Replace each package with proper casing.
             for dep in p[section].keys():
@@ -115,14 +115,13 @@ def ensure_proper_casing():
 
                 # Mark casing as changed, if it did.
                 casing_changed = True
-                old_keys.append(dep)
+                changed_values.append((new_casing, dep))
 
+            for new, old in changed_values:
                 # Replace old value with new value.
-                old_value = p[section][dep]
-                p[section][new_casing] = old_value
-
-            for key in old_keys:
-                del p[section][key]
+                old_value = p[section][old]
+                p[section][new] = old_value
+                del p[section][old]
 
         return casing_changed
 

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -1,10 +1,8 @@
 import os
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
 
 import toml
+
+from requests.compat import OrderedDict
 
 from . import _pipfile as pipfile
 from .utils import format_toml, multi_split


### PR DESCRIPTION
This should fix the current issues with the OrderdDict changes in the build. There's a certain amount of complexity in using OrderedDict in older versions of Python (specifically 2.6) that's already been handled in Requests. Since that is a hard dependency I leveraged it's OrderedDict implementation to spare us the headache. Hopefully that's OK.