### PR TITLE
consolidating ensure checks to virtualenv when possible

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,3 +1,5 @@
+3.2.5:
+ - Significant speed improvements for pipenv run and pipenv shell.
 3.2.4:
  - $ pipenv uninstall --all
  - Don't uninstall setuptools, wheel, pip, or six.

--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -710,7 +710,7 @@ def lock(three=None):
 @click.option('--three/--two', is_flag=True, default=None, help="Use Python 3/2 when creating virtualenv.")
 def shell(three=None):
     # Ensure that virtualenv is available.
-    ensure_project(three=three)
+    ensure_virtualenv(three=three)
 
     # Set an environment variable, so we know we're in the environment.
     os.environ['PIPENV_ACTIVE'] = '1'
@@ -765,7 +765,7 @@ def shell(three=None):
 @click.option('--three/--two', is_flag=True, default=None, help="Use Python 3/2 when creating virtualenv.")
 def run(command, args, three=None):
     # Ensure that virtualenv is available.
-    ensure_project(three=three)
+    ensure_virtualenv(three=three)
 
     # Spawn the new process, and interact with it.
     try:


### PR DESCRIPTION
`ensure_project` requires that both the virtualenv and pipfile are checked. The `check_pipfile` function is time consuming, especially as your Pipfile gets bigger, which can lead to multiple second delays. While this is acceptable for installation, it makes using `pipenv run` and `pipenv shell` painful as noted in #120.

Since `pipenv run` and `pipenv shell` never actually use the pipfile, we can safely skip that step and only verify the virtualenv is running. This results in an ~7x speed increase in my local testing with a pipfile of 20 entries.

Before:
```
$ time pipenv run python --version
Python 3.6.0

real	0m4.061s
user	0m1.222s
sys	0m0.136s
```

After:
```
$ time pipenv run python --version
Python 3.6.0

real	0m0.583s
user	0m0.370s
sys	0m0.087s
```