### PR TITLE
Qualfied version of requests required to >2.3.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,13 +1,13 @@
-[dev-packages]
-pytest = "*"
-
 [packages]
 click = "*"
 crayons = "*"
 toml = "*"
 "delegator.py" = ">=0.0.6"
-requests = "*"
+requests = ">=2.4.0"
 requirements-parser = "*"
 parse = "*"
 "backports.shutil_get_terminal_size" = "*"
 pipfile = "==0.0.1"
+
+[dev-packages]
+pytest = "*"

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ required = [
     'requirements-parser',
     'pexpect',
     'pipfile==0.0.1',
-    'requests>2.3.0'
+    'requests>=2.4.0'
 ]
 
 # Backport required for earlier versions of Python.

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ required = [
     'requirements-parser',
     'pexpect',
     'pipfile==0.0.1',
-    'requests'
+    'requests>2.3.0'
 ]
 
 # Backport required for earlier versions of Python.

--- a/tests/requirements_requests.txt
+++ b/tests/requirements_requests.txt
@@ -1,1 +1,1 @@
-requests
+requests>2.3.0


### PR DESCRIPTION
I successfully installed `pipenv` with `pip` and tried to run for the first time only to encounter this error:

```
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.4/bin/pipenv", line 11, in <module>
    load_entry_point('pipenv==3.2.4', 'console_scripts', 'pipenv')()
  File "/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/pkg_resources/__init__.py", line 560, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2642, in load_entry_point
    return ep.load()
  File "/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2296, in load
    return self.resolve()
  File "/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2302, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/pipenv/__init__.py", line 1, in <module>
    from .cli import cli
  File "/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/pipenv/cli.py", line 17, in <module>
    from requests.packages.urllib3.exceptions import InsecureRequestWarning
ImportError: cannot import name 'InsecureRequestWarning'
```

This was due to my installed version of `requests` being 2.3.0.  Upon upgrading `requests` to 2.4.0 and above, pipenv runs fine.  

As such, I've qualified the version requirement in `setup.py`

