### PR TITLE
perform proper_case as best effort approach

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,6 +1,7 @@
 3.2.5:
  - Significant speed improvements for pipenv run and pipenv shell.
  - Shell completion via click-completion.
+ - Perform package name normalization as best effort attempt.
 3.2.4:
  - $ pipenv uninstall --all
  - Don't uninstall setuptools, wheel, pip, or six.

--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -110,8 +110,14 @@ def ensure_proper_casing():
             # Replace each package with proper casing.
             for dep in p[section].keys():
 
-                # Get new casing for package name.
-                new_casing = proper_case(dep)
+                # Attempt to normalize name from PyPI.
+                # Use provided name if better one can't be found.
+                try:
+                    # Get new casing for package name.
+                    new_casing = proper_case(dep)
+                except IOError:
+                    # Unable to normalize package name.
+                    continue
 
                 if new_casing == dep:
                     continue


### PR DESCRIPTION
This is an attempt to solve #129. pipenv will try to normalize all keys against the name provided in the package repository provided in [source]. This functionality broke dependencies from alternative sources, such as git. Instead of performing a hard fail on not finding a package, we will now treat normalization as a best effort. If we can't find a better option, let's trust the user to provide what they want.