### PR TITLE
only write file when changed

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -139,8 +139,8 @@ def ensure_proper_casing():
     if casing_changed:
         click.echo(crayons.yellow('Fixing package names in Pipfile...'))
 
-    # Write pipfile out to disk.
-    project.write(p)
+        # Write pipfile out to disk.
+        project.write(p)
 
 
 def do_where(virtualenv=False, bare=True):


### PR DESCRIPTION
We write the Pipfile at the beginning of every run regardless of if it changed or not. Let's only record changes.