### PR TITLE
Link pip and virtualenv projects in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Pipenv: Sacred Marriage of Pipfile, Pip, & Virtualenv
 ---------------
 
 
-**Pipenv** is an experimental project that aims to bring the best of all packaging worlds to the Python world. It harnesses `Pipfile <https://github.com/pypa/pipfile>`_, pip, and virtualenv into one single toolchain. It features very pretty terminal colors.
+**Pipenv** is an experimental project that aims to bring the best of all packaging worlds to the Python world. It harnesses `Pipfile <https://github.com/pypa/pipfile>`_, `pip <https://github.com/pypa/pip>`_, and `virtualenv <https://github.com/pypa/virtualenv>`_ into one single toolchain. It features very pretty terminal colors.
 
 It automatically creates and manages a virtualenv for your projects, as well as adds/removes packages from your ``Pipfile`` as you install/uninstall packages. The ``lock`` command generates a lockfile (``Pipfile.lock``).
 


### PR DESCRIPTION
Pipfile is linked to it's GitHub repository. I added links for *pip* and *virtualenv*, too.