### PR TITLE
verify package version before adding it to Pipfile.lock

### DIFF
--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -131,4 +131,10 @@ def mkdir_p(newdir):
         if tail:
             os.mkdir(newdir)
 
-
+def is_required_version(version, specified_version):
+    """Check to see if there's a hard requirement for version
+    number provided in the Pipfile.
+    """
+    if specified_version.startswith('=='):
+        return version.strip() == specified_version.split('==')[1].strip()
+    return True


### PR DESCRIPTION
This addresses #148 where we had a possible overwriting condition that caused an unexpected version number to appear in some Pipfile configurations. We will now verify version numbers against hard pinned version in the Pipfile.