### PR TITLE
Improve parse_download_fname performance

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -345,7 +345,7 @@ def parse_download_fname(fname):
 
     fname_components = fname.split('-')
     for fname_component in fname_components:
-        if is_version(fname_component):
+        if not have_found_version_start and is_version(fname_component):
             have_found_version_start = True
         if have_found_version_start:
             if len(version) > 0:


### PR DESCRIPTION
This is a small performance-oriented followup to #175 which should ~halve the amount of regex being run!

Once the beginning of the version string has been found, the flag is no longer modified, and thus there's no reason to keep running the regex.