### PR TITLE
Add PIPENV_NOSPIN option for cleaner build logs

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,3 +1,5 @@
+unreleased:
+- Disable spinner by setting PIPENV_NOSPIN=1 environment variable.
 3.3.4:
  - Fix PIPENV_VENV_IN_PROJECT mode.
  - Fix PIPENV_SHELL_COMPAT mode.

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -91,6 +91,8 @@ will detect it.
 
     - ``PIPENV_COLORBLIND`` — Disable terminal colors, for some reason.
 
+    - ``PIPENV_NOSPIN`` — Disable terminal spinner, for cleaner logs.
+
     - ``PIPENV_MAX_DEPTH`` — Set to an integer for the maximum number of directories to
                                search for a Pipfile.
 

--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -23,7 +23,7 @@ from .project import Project
 from .utils import convert_deps_from_pip, convert_deps_to_pip, is_required_version
 from .__version__ import __version__
 from . import pep508checker
-from .environments import PIPENV_COLORBLIND, PIPENV_SHELL_COMPAT, PIPENV_VENV_IN_PROJECT
+from .environments import PIPENV_COLORBLIND, PIPENV_NOSPIN, PIPENV_SHELL_COMPAT, PIPENV_VENV_IN_PROJECT
 
 try:
     from HTMLParser import HTMLParser
@@ -48,6 +48,13 @@ click_completion.init()
 # Disable colors, for the soulless.
 if PIPENV_COLORBLIND:
     crayons.disable()
+
+# Disable spinner, for cleaner build logs.
+if PIPENV_NOSPIN:
+    import contextlib
+    @contextlib.contextmanager
+    def spinner():
+        yield
 
 # Disable warnings for Python 2.6.
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -15,6 +15,9 @@ PIPENV_VENV_IN_PROJECT = os.environ.get('PIPENV_VENV_IN_PROJECT')
 # No color mode, for unfun people.
 PIPENV_COLORBLIND = os.environ.get('PIPENV_COLORBLIND')
 
+# Disable spinner for better test and deploy logs.
+PIPENV_NOSPIN = os.environ.get('PIPENV_NOSPIN')
+
 # User-configuraable max-depth for Pipfile searching.
 # Note: +1 because of a bug in Pipenv.
 PIPENV_MAX_DEPTH = int(os.environ.get('PIPENV_MAX_DEPTH', '3')) + 1


### PR DESCRIPTION
I would like to be able to clean up this noise on CircleCI:

<img width="575" alt="screen shot 2017-02-02 at 1 02 59 pm" src="https://cloud.githubusercontent.com/assets/939501/22561819/f80a0fb6-e947-11e6-83cf-aba39222a94d.png">
