### PR TITLE
disable spinner for 2.6

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -50,6 +50,11 @@ click_completion.init()
 if PIPENV_COLORBLIND:
     crayons.disable()
 
+# Disable spinner for Python 2.6 due to unicode conflict.
+# TODO: Remove me when blindspin is patched.
+if sys.version_info[0:2] == (2, 6):
+    PIPENV_NOSPIN = True
+
 # Disable spinner, for cleaner build logs (the unworthy).
 if PIPENV_NOSPIN:
     @contextlib.contextmanager


### PR DESCRIPTION
Temporarily disable spinner until a patch is merged to fix blindspin for 2.6.