### PR TITLE
Enable basic functionality for Windows OS

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -577,9 +577,9 @@ def pip_download(package_name):
 
 def which(command):
     if project.is_running_on_windows:
-        python_location = "Scripts" + os.sep + command + ".exe"
+        python_location = 'Scripts' + os.sep + command + '.exe'
     else:
-        python_location = ['bin/{0}'.format(command)]
+        python_location = 'bin/{0}'.format(command)
     return os.sep.join([project.virtualenv_location] + [python_location])
 
 

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -124,6 +124,10 @@ class Project(object):
         else:
             return {u'url': u'https://pypi.python.org/simple', u'verify_ssl': True}
 
+    @property
+    def is_running_on_windows(self):
+        return os.name == 'nt'
+
     def remove_package_from_pipfile(self, package_name, dev=False):
         pipfile_path = pipfile.Pipfile.find()
 


### PR DESCRIPTION
This pull request aims to bring basic compatibility with Windows OS (as I love pipenv but need it to work across windows/linux).
Currently I believe I have made all commands except for `shell` to work. 

I know the approach taken is not ideal (comments are welcomed), however this unblocks any workflow that requires projects to be created with venv both on Windows and Linux. 

Caveats: Pipfile available from pypi needs to be upgraded, otherwise it will return invalid path on Windows ([relevant issue]( https://github.com/pypa/pipfile/issues/67))
