### PR TITLE
Use safe_name from pkg_resources for proper_case

### DIFF
--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -59,25 +59,6 @@ class Project(object):
         return d_dir
 
     @property
-    def proper_names_location(self):
-        pn_file = os.sep.join(self.virtualenv_location.split(os.sep) + ['pipenev-proper-names.txt'])
-
-        # Create the database, if it doesn't exist.
-        open(pn_file, 'a').close()
-
-        return pn_file
-
-    @property
-    def proper_names(self):
-        with open(self.proper_names_location) as f:
-            return f.read().splitlines()
-
-    def register_proper_name(self, name):
-        """Registers a proper name to the database."""
-        with open(self.proper_names_location, 'a') as f:
-            f.write('{0}\n'.format(name))
-
-    @property
     def pipfile_location(self):
         try:
             return pipfile.Pipfile.find(max_depth=PIPENV_MAX_DEPTH)


### PR DESCRIPTION
As far as I understand, the purpose of `proper_case` is to find a somehow "normalized" name of a package. The current way for doing this is to hit the PyPI's simple package index page, and fetch the title text. Now, if we can figure out how exactly PyPI produces that "normalized" package name, we can simply apply the same rule inside pipenv, without exhaustively making requests and caching the results. So I've changed the `proper_case` function to exactly how [PyPI's simple package index produces the package name](https://github.com/pypa/pypi-legacy/blob/master/webui.py#L1082).

Please let me know if I misunderstood anything about the purpose of `proper_case`, or about the reasons behind checking proper names by asking PyPI.