### PR TITLE
Fix PyPI simple API URL

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -186,7 +186,7 @@
     "_meta": {
         "sources": [
             {
-                "url": "https://pypi.python.org/simple",
+                "url": "https://pypi.org/simple",
                 "verify_ssl": true
             }
         ],

--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -588,7 +588,7 @@ def proper_case(package_name):
                 collected.append(data)
 
     # Hit the simple API.
-    r = requests.get('https://pypi.org/simple/{0}'.format(package_name))
+    r = requests.get('{0}/{1}/'.format(project.source['url'], package_name))
     if not r.ok:
         raise IOError('Unable to find package {0} in PyPI repository.'.format(crayons.green(package_name)))
 

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -117,7 +117,7 @@ class Project(object):
             return json.load(lock)
 
     def create_pipfile(self):
-        data = {u'source': [{u'url': u'https://pypi.python.org/simple', u'verify_ssl': True}], u'packages': {}, 'dev-packages': {}}
+        data = {u'source': [{u'url': u'https://pypi.org/simple', u'verify_ssl': True}], u'packages': {}, 'dev-packages': {}}
         self.write_toml(data, 'Pipfile')
 
     def write_toml(self, data, path=None):
@@ -136,7 +136,7 @@ class Project(object):
         if 'source' in self.parsed_pipfile:
             return self.parsed_pipfile['source'][0]
         else:
-            return {u'url': u'https://pypi.python.org/simple', u'verify_ssl': True}
+            return {u'url': u'https://pypi.org/simple', u'verify_ssl': True}
 
     def remove_package_from_pipfile(self, package_name, dev=False):
 


### PR DESCRIPTION
Follow up as a comment for #215, if the purpose of `proper_case` is to get the "official registered" name of the package on PyPI, then fetching the text on https://pypi.python.org/simple wouldn't help anything, it'll turn out to be the "normalized" package name.

@nateprewitt also referenced an example of [Twisted](https://pypi.org/simple/twisted/), which supposed to be "Twisted" instead of "twisted", but since pipenv is currently referencing pypi.python.org instead of pypi.org, it actually shows ["twisted" instead of "Twisted"](https://pypi.python.org/simple/twisted/), so it wouldn't fix the problem of "proper casing". I think hitting pypi.org/simple gives our expected result, right?