### PR TITLE
Make pip_download respect project.sources

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -565,7 +565,18 @@ def pip_install(package_name=None, r=None, allow_global=False):
 
 
 def pip_download(package_name):
-    c = delegator.run('{0} download "{1}" -d {2}'.format(which_pip(), package_name, project.download_location))
+    for source in project.sources:
+        c = delegator.run(
+            '{0} download "{1}"  -i {2} -d {3}'.format(
+                which_pip(),
+                package_name,
+                source['url'],
+                project.download_location
+            )
+        )
+        if c.return_code == 0:
+            break
+
     return c
 
 

--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -566,14 +566,13 @@ def pip_install(package_name=None, r=None, allow_global=False):
 
 def pip_download(package_name):
     for source in project.sources:
-        c = delegator.run(
-            '{0} download "{1}"  -i {2} -d {3}'.format(
-                which_pip(),
-                package_name,
-                source['url'],
-                project.download_location
-            )
+        cmd = '{0} download "{1}"  -i {2} -d {3}'.format(
+            which_pip(),
+            package_name,
+            source['url'],
+            project.download_location
         )
+        c = delegator.run(cmd)
         if c.return_code == 0:
             break
 

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -7,7 +7,7 @@ import delegator
 import toml
 
 from pipenv.cli import (activate_virtualenv, ensure_proper_casing,
-    parse_download_fname, parse_install_output, pip_install)
+    parse_download_fname, parse_install_output, pip_install, pip_download, which_pip)
 from pipenv.project import Project
 
 
@@ -182,5 +182,55 @@ class TestPipenv():
         second_cmd_return.return_code = 0
         mocked_delegator.side_effect = [first_cmd_return, second_cmd_return]
         c = pip_install('package')
+        assert c.return_code == 0
+        assert c == first_cmd_return
+
+    @patch('pipenv.project.Project.sources', new_callable=PropertyMock)
+    @patch('delegator.run')
+    def test_pip_download_should_try_every_possible_source(self, mocked_delegator, mocked_sources):
+        sources = [
+            {'url': 'http://dontexistis.in.pypi/simple'},
+            {'url': 'http://existis.in.pypi/simple'}
+        ]
+        mocked_sources.return_value = sources
+        first_cmd_return = Mock()
+        first_cmd_return.return_code = 1
+        second_cmd_return = Mock()
+        second_cmd_return.return_code = 0
+        mocked_delegator.side_effect = [first_cmd_return, second_cmd_return]
+        c = pip_download('package')
+        assert c.return_code == 0
+
+    @patch('pipenv.project.Project.sources', new_callable=PropertyMock)
+    @patch('delegator.run')
+    def test_pip_download_should_return_the_last_error_if_no_cmd_worked(self, mocked_delegator, mocked_sources):
+        sources = [
+            {'url': 'http://dontexistis.in.pypi/simple'},
+            {'url': 'http://dontexistis.in.pypi/simple'}
+        ]
+        mocked_sources.return_value = sources
+        first_cmd_return = Mock()
+        first_cmd_return.return_code = 1
+        second_cmd_return = Mock()
+        second_cmd_return.return_code = 1
+        mocked_delegator.side_effect = [first_cmd_return, second_cmd_return]
+        c = pip_download('package')
+        assert c.return_code == 1
+        assert c == second_cmd_return
+
+    @patch('pipenv.project.Project.sources', new_callable=PropertyMock)
+    @patch('delegator.run')
+    def test_pip_download_should_return_the_first_cmd_that_worked(self, mocked_delegator, mocked_sources):
+        sources = [
+            {'url': 'http://existis.in.pypi/simple'},
+            {'url': 'http://existis.in.pypi/simple'}
+        ]
+        mocked_sources.return_value = sources
+        first_cmd_return = Mock()
+        first_cmd_return.return_code = 0
+        second_cmd_return = Mock()
+        second_cmd_return.return_code = 0
+        mocked_delegator.side_effect = [first_cmd_return, second_cmd_return]
+        c = pip_download('package')
         assert c.return_code == 0
         assert c == first_cmd_return


### PR DESCRIPTION
As stated in #231, `pip_download` (function used by the pipenv lock command) ins't using the project.sources to download the pypackages.
I changed it so that `pip_download` would work like `pip_install` and try downloading using each of the defined `project.sources` as the `index-url` in the `pip` md.

Also added some tests fo check for this behavior.

fix #231 