### PR TITLE
Fix VCS dependencies

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,7 +1,7 @@
 [dev-packages]
 pytest = "*"
-sphinx = "*"
 mock = "*"
+Sphinx = "*"
 
 [packages]
 click = "*"
@@ -14,9 +14,9 @@ parse = "*"
 pipfile = "==0.0.1"
 click-completion = "*"
 psutil = "*"
-"backports.shutil-get-terminal-size" = "*"
 pew = ">=0.1.26"
 blindspin = "*"
+"backports.shutil_get_terminal_size" = "*"
 
 [requires]
 python_version = "2.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -8,17 +8,21 @@
             "version": "==0.1.0",
             "hash": "sha256:fee2380a469ffe4067bc7f0096a6fcfb27539da7496fae12b74b8d5d0f33a4ee"
         },
-        "backports.shutil-get-terminal-size": {
-            "version": "==1.0.0",
-            "hash": "sha256:0975ba55054c15e346944b38956a4c9cbee9009391e41b86c68990effb8c1f64"
+        "requests": {
+            "version": "==2.13.0",
+            "hash": "sha256:1a720e8862a41aa22e339373b526f508ef0c8988baf48b84d3fc891a8e237efb"
         },
         "blindspin": {
             "version": "==2.0.1",
             "hash": "sha256:b30ef7a26ef1637c1d047667b279e8c15dc2a78fcfaad6b3027d7217e752bdba"
         },
-        "parse": {
-            "version": "==1.6.6",
-            "hash": "sha256:a4862be306f334c36ae7adc73af028c56ca0139b8e39435e935bde8d481dd99e"
+        "Jinja2": {
+            "version": "==2.9.5",
+            "hash": "sha256:a7b7438120dbe76a8e735ef7eba6048eaf4e0b7dbc530e100812f8ec462a4d50"
+        },
+        "packaging": {
+            "version": "==16.8",
+            "hash": "sha256:99276dc6e3a7851f32027a68f1095cd3f77c148091b092ea867a351811cfe388"
         },
         "MarkupSafe": {
             "version": "==0.23",
@@ -36,21 +40,21 @@
             "version": "==0.2.1",
             "hash": "sha256:079fb138887d4de12a0b7fbebf8d92d396b7c1a9c49f63475d9f3909d2588976"
         },
-        "pipfile": {
-            "version": "==0.0.1",
-            "hash": "sha256:a0bf9924d9bd25fa5e216d643fde49ff67f48727cb711a02ad806bf7c4722ea2"
+        "click": {
+            "version": "==6.7",
+            "hash": "sha256:29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d"
         },
         "appdirs": {
-            "version": "==1.4.0",
-            "hash": "sha256:85e58578db8f29538f3109c11250c2a5514a2fcdc9890d9b2fe777eb55517736"
+            "version": "==1.4.2",
+            "hash": "sha256:a53330b9d53b66aba1e26907dea2958982ebad92735f9faf3897b73c909a20c1"
         },
         "virtualenv": {
             "version": "==15.1.0",
             "hash": "sha256:39d88b533b422825d644087a21e78c45cf5af0ef7a99a1fc9fbb7b481e5c85b0"
         },
-        "packaging": {
-            "version": "==16.8",
-            "hash": "sha256:99276dc6e3a7851f32027a68f1095cd3f77c148091b092ea867a351811cfe388"
+        "parse": {
+            "version": "==1.8.0",
+            "hash": "sha256:8b4f28bbe7c0f24981669ea92b2ba704ee63b5346027e82be30118bb5788ff10"
         },
         "pexpect": {
             "version": "==4.2.1",
@@ -76,13 +80,13 @@
             "version": "==0.1.26",
             "hash": "sha256:259ac7a4603fe41b1fa950f30b2e4ccf4a23f7c89be2c34e0a4cec176c3ec581"
         },
+        "backports.shutil_get_terminal_size": {
+            "version": "==1.0.0",
+            "hash": "sha256:0975ba55054c15e346944b38956a4c9cbee9009391e41b86c68990effb8c1f64"
+        },
         "ptyprocess": {
             "version": "==0.5.1",
             "hash": "sha256:464cb76f7a7122743dd25507650db89cd447c51f38e4671602b3eaa2e38e05ae"
-        },
-        "click": {
-            "version": "==6.7",
-            "hash": "sha256:29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d"
         },
         "six": {
             "version": "==1.10.0",
@@ -97,16 +101,12 @@
             "hash": "sha256:b3953bffe848ad9a6d554114d82f2dcb3e23945e90b4d9addc9956f37f336594"
         },
         "setuptools": {
-            "version": "==34.2.0",
-            "hash": "sha256:75d352eeeddd96a3fb702b1da9f8b89e5f8c045dbd86e3894516733eb5f99713"
+            "version": "==34.3.0",
+            "hash": "sha256:ef40d2d360ba1be284a47c51a5a489afa7d8cde5ca39f2321876e00e93fe04cd"
         },
-        "jinja2": {
-            "version": "==2.9.5",
-            "hash": "sha256:a7b7438120dbe76a8e735ef7eba6048eaf4e0b7dbc530e100812f8ec462a4d50"
-        },
-        "requests": {
-            "version": "==2.13.0",
-            "hash": "sha256:1a720e8862a41aa22e339373b526f508ef0c8988baf48b84d3fc891a8e237efb"
+        "pipfile": {
+            "version": "==0.0.1",
+            "hash": "sha256:a0bf9924d9bd25fa5e216d643fde49ff67f48727cb711a02ad806bf7c4722ea2"
         }
     },
     "develop": {
@@ -114,13 +114,17 @@
             "version": "==1.10.0",
             "hash": "sha256:0ff78c403d9bccf5a425a6d31a12aa6b47f1c21ca4dc2573a7e2f32a97335eb1"
         },
+        "snowballstemmer": {
+            "version": "==1.2.1",
+            "hash": "sha256:9f3bcd3c401c3e862ec0ebe6d2c069ebc012ce142cce209c098ccb5b09136e89"
+        },
         "py": {
             "version": "==1.4.32",
             "hash": "sha256:2d4bba2e25fff58140e6bdce1e485e89bb59776adbe01d490baa6b1f37a3dd6b"
         },
-        "sphinx": {
-            "version": "==1.5.2",
-            "hash": "sha256:57c8636e1d23f6c01fb19911a8f255f1b4934ba69feb55bd4dd0f097ebb04f05"
+        "Sphinx": {
+            "version": "==1.5.3",
+            "hash": "sha256:2809b2ab81906483b47c9d7e28740e3b69c160617f33d7aa11dc4ae376fd04d9"
         },
         "imagesize": {
             "version": "==0.7.1",
@@ -134,11 +138,7 @@
             "version": "==0.23",
             "hash": "sha256:a4ec1aff59b95a14b45eb2e23761a0179e98319da5a7eb76b56ea8cdc7b871c3"
         },
-        "snowballstemmer": {
-            "version": "==1.2.1",
-            "hash": "sha256:9f3bcd3c401c3e862ec0ebe6d2c069ebc012ce142cce209c098ccb5b09136e89"
-        },
-        "babel": {
+        "Babel": {
             "version": "==2.3.4",
             "hash": "sha256:3318ed2960240d61cbc6558858ee00c10eed77a6508c4d1ed8e6f7f48399c975"
         },
@@ -150,10 +150,6 @@
             "version": "==1.10.0",
             "hash": "sha256:f5cf7265a80636ecff66806d13494cbf9d77a3758a65fd8b4d4d4bee81b0c375"
         },
-        "pytest": {
-            "version": "==3.0.6",
-            "hash": "sha256:da0ab50c7eec0683bc24f1c1137db1f4111752054ecdad63125e7ec71316b813"
-        },
         "packaging": {
             "version": "==16.8",
             "hash": "sha256:99276dc6e3a7851f32027a68f1095cd3f77c148091b092ea867a351811cfe388"
@@ -162,21 +158,25 @@
             "version": "==0.13.1",
             "hash": "sha256:cb3ebcb09242804f84bdbf0b26504077a054da6772c6f4d625f335cc53ebf94d"
         },
-        "Pygments": {
-            "version": "==2.2.0",
-            "hash": "sha256:78f3f434bcc5d6ee09020f92ba487f95ba50f1e3ef83ae96b9d5ffa1bab25c5d"
+        "pytest": {
+            "version": "==3.0.6",
+            "hash": "sha256:da0ab50c7eec0683bc24f1c1137db1f4111752054ecdad63125e7ec71316b813"
         },
         "Jinja2": {
             "version": "==2.9.5",
             "hash": "sha256:a7b7438120dbe76a8e735ef7eba6048eaf4e0b7dbc530e100812f8ec462a4d50"
         },
         "appdirs": {
-            "version": "==1.4.0",
-            "hash": "sha256:85e58578db8f29538f3109c11250c2a5514a2fcdc9890d9b2fe777eb55517736"
+            "version": "==1.4.2",
+            "hash": "sha256:a53330b9d53b66aba1e26907dea2958982ebad92735f9faf3897b73c909a20c1"
         },
         "setuptools": {
-            "version": "==34.2.0",
-            "hash": "sha256:75d352eeeddd96a3fb702b1da9f8b89e5f8c045dbd86e3894516733eb5f99713"
+            "version": "==34.3.0",
+            "hash": "sha256:ef40d2d360ba1be284a47c51a5a489afa7d8cde5ca39f2321876e00e93fe04cd"
+        },
+        "Pygments": {
+            "version": "==2.2.0",
+            "hash": "sha256:78f3f434bcc5d6ee09020f92ba487f95ba50f1e3ef83ae96b9d5ffa1bab25c5d"
         },
         "pyparsing": {
             "version": "==2.1.10",
@@ -202,7 +202,7 @@
             "python_version": "2.7"
         },
         "hash": {
-            "sha256": "c1291a920a500f47bed4d4e22c0cc8354cb2b72304010a05e3ef0aed0c4e06cd"
+            "sha256": "33bb704e3081ebcb3c18c3a36ef4b26218e52e2f1075c34b1a11ac0d18198d42"
         }
     }
 }

--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -758,7 +758,10 @@ def install(package_name=False, more_packages=False, dev=False, three=False, pyt
             click.echo('Adding {0} to Pipfile\'s {1}...'.format(crayons.green(package_name), crayons.red('[packages]')))
 
         # Add the package to the Pipfile.
-        project.add_package_to_pipfile(package_name, dev)
+        try:
+            project.add_package_to_pipfile(package_name, dev)
+        except ValueError as e:
+            click.echo('{0} {1}'.format(crayons.red('ERROR (PACKAGE NOT INSTALLED):'), e))
 
         # Ego boost.
         easter_egg(package_name)

--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -766,8 +766,8 @@ def install(package_name=False, more_packages=False, dev=False, three=False, pyt
         # Ego boost.
         easter_egg(package_name)
 
-        if lock:
-            do_lock()
+    if lock:
+        do_lock()
 
 
 @click.command(help="Un-installs a provided package and removes it from Pipfile, or (if none is given), un-installs all packages.")

--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -353,10 +353,6 @@ def do_create_virtualenv(three=None, python=None):
     do_where(virtualenv=True, bare=False)
 
 
-def is_version(text):
-    return re.match('^[\d]+\.[\d]+.*', text) or False
-
-
 def parse_download_fname(fname, name):
     fname, fextension = os.path.splitext(fname)
 

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -11,8 +11,8 @@ import toml
 import delegator
 from requests.compat import OrderedDict
 
-from .utils import format_toml, mkdir_p
-from .utils import convert_deps_from_pip
+from .utils import (format_toml, mkdir_p, convert_deps_from_pip,
+    proper_case, pep426_name, VCS_LIST)
 from .environments import PIPENV_MAX_DEPTH, PIPENV_VENV_IN_PROJECT
 
 

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -12,7 +12,7 @@ import delegator
 from requests.compat import OrderedDict
 
 from .utils import (format_toml, mkdir_p, convert_deps_from_pip,
-    proper_case, pep426_name, VCS_LIST)
+    proper_case, pep426_name, is_vcs)
 from .environments import PIPENV_MAX_DEPTH, PIPENV_VENV_IN_PROJECT
 
 
@@ -131,6 +131,68 @@ class Project(object):
             return toml.load(f, _dict=OrderedDict)
 
     @property
+    def _pipfile(self):
+        """Pipfile divided by PyPI and external dependencies."""
+        pfile = self.parsed_pipfile
+        for section in ('packages', 'dev-packages'):
+            p_section = pfile.get(section, {})
+
+            for key in list(p_section.keys()):
+                # Normalize key name to pep426.
+                norm_key = pep426_name(key)
+                p_section[norm_key] = p_section.pop(key)
+
+        return pfile
+
+    def split_vcs(self, split_file):
+        """Split VCS dependencies out from file."""
+        if 'packages' in split_file or 'dev-packages' in split_file:
+            sections = ('packages', 'dev-packages')
+        elif 'default' in split_file or 'develop' in split_file:
+            sections = ('default', 'develop')
+
+        for section in sections:
+            entries = split_file.get(section, {})
+            vcs_dict = dict((k, entries.pop(k)) for k in list(entries.keys()) if is_vcs(entries[k]))
+            split_file[section+'-vcs'] = vcs_dict
+
+        return split_file
+
+    def recase_file(self, in_file):
+        """Recase file before writing to output."""
+        if 'packages' in in_file or 'dev-packages' in in_file:
+            sections = ('packages', 'dev-packages')
+        elif 'default' in in_file or 'develop' in in_file:
+            sections = ('default', 'develop')
+
+        for section in sections:
+            file_section = in_file.get(section, {})
+
+            for key in list(file_section.keys()):
+                try:
+                    cased_key = proper_case(key)
+                except IOError:
+                    cased_key = key
+                file_section[cased_key] = file_section.pop(key)
+
+        return in_file
+
+    @property
+    def _lockfile(self):
+        """Pipfile.lock divided by PyPI and external dependencies."""
+        pfile = pipfile.load(self.pipfile_location)
+        lockfile = json.loads(pfile.lock())
+
+        for section in ('default', 'develop'):
+            lock_section = lockfile.get(section, {})
+
+            for key in list(lock_section.keys()):
+                norm_key = pep426_name(key)
+                lockfile[section][norm_key] = lock_section.pop(key)
+
+        return lockfile
+
+    @property
     def lockfile_location(self):
         return '{0}.lock'.format(self.pipfile_location)
 
@@ -170,21 +232,22 @@ class Project(object):
     def remove_package_from_pipfile(self, package_name, dev=False):
 
         # Read and append Pipfile.
-        p = self.parsed_pipfile
+        p = self._pipfile
+
+        package_name = pep426_name(package_name)
 
         key = 'dev-packages' if dev else 'packages'
 
-        if key in p:
-            if package_name in p[key]:
-                del p[key][package_name]
+        if key in p and package_name in p[key]:
+            del p[key][package_name]
 
         # Write Pipfile.
-        self.write_toml(p)
+        self.write_toml(self.recase_file(p))
 
     def add_package_to_pipfile(self, package_name, dev=False):
 
         # Read and append Pipfile.
-        p = self.parsed_pipfile
+        p = self._pipfile
 
         key = 'dev-packages' if dev else 'packages'
 
@@ -199,4 +262,4 @@ class Project(object):
         p[key][package_name] = package[package_name]
 
         # Write Pipfile.
-        self.write_toml(p)
+        self.write_toml(self.recase_file(p))

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -51,6 +51,11 @@ def convert_deps_from_pip(dep):
 
     # VCS Installs.
     elif req.vcs:
+        if req.name is None:
+            raise ValueError('pipenv requires an #egg fragment for version controlled '
+                             'dependencies. Please install remote dependency '
+                             'in the form {0}#egg=<package-name>.'.format(req.uri))
+
         # Crop off the git+, etc part.
         dependency[req.name] = {req.vcs: req.uri[len(req.vcs) + 1:]}
 

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -155,6 +155,12 @@ def is_required_version(version, specified_version):
     return True
 
 
+def is_vcs(pipfile_entry):
+    """Determine if dictionary entry from Pipfile is for a vcs dependency."""
+    if isinstance(pipfile_entry, dict):
+        return any(key for key in pipfile_entry.keys() if key in VCS_LIST)
+    return False
+
 def pep426_name(name):
     """Normalize package name to pep426 style standard."""
     return name.lower().replace('_','-')

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -187,7 +187,7 @@ def proper_case(package_name):
     # Hit the simple API.
     r = requests.get('https://pypi.org/simple/{0}'.format(package_name))
     if not r.ok:
-        raise IOError('Unable to find package {0} in PyPI repository.'.format(crayons.green(package_name)))
+        raise IOError('Unable to find package {0} in PyPI repository.'.format(package_name))
 
     # Parse the HTML.
     parser = SimpleHTMLParser()

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -39,10 +39,19 @@ class TestPipenv():
         assert delegator.run('pipenv --python python').return_code == 0
         assert delegator.run('pipenv install requests').return_code == 0
         assert delegator.run('pipenv install pytest --dev').return_code == 0
+        assert delegator.run('pipenv install git+https://github.com/kennethreitz/records.git@v0.5.0#egg=records').return_code == 0
         assert delegator.run('pipenv lock').return_code == 0
 
-        assert 'pytest' in delegator.run('cat Pipfile').out
-        assert 'pytest' in delegator.run('cat Pipfile.lock').out
+        pipfile_output = delegator.run('cat Pipfile').out
+        lockfile_output = delegator.run('cat Pipfile.lock').out
+
+        # Ensure dev-packages work.
+        assert 'pytest' in pipfile_output
+        assert 'pytest' in lockfile_output
+
+        # Ensure vcs dependencies work.
+        assert 'records' in pipfile_output
+        assert '"git": "https://github.com/kennethreitz/records.git"' in lockfile_output
 
         os.chdir('..')
         delegator.run('rm -fr test_project')

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -64,6 +64,7 @@ class TestProject():
 
         proj.add_package_to_pipfile('Flask')
         proj.add_package_to_pipfile('Django==1.10.1', dev=True)
+        proj.add_package_to_pipfile('Click-ComPletiON')
         p = proj.parsed_pipfile
 
         # Cleanup test space.
@@ -77,6 +78,10 @@ class TestProject():
         assert 'Django' in p['dev-packages']
         assert p['dev-packages']['Django'] == '==1.10.1'
 
+        # Confirm casing is normalized.
+        assert 'click-completion' in p['packages']
+        assert p['packages']['click-completion'] == '*'
+
     def test_remove_package_from_pipfile(self):
         proj = pipenv.project.Project()
 
@@ -86,17 +91,18 @@ class TestProject():
             f.write('[[source]]\nurl = \'https://pypi.python.org/simple\'\n'
                     'verify_ssl = true\n\n\n[packages]\n'
                     'requests = { extras = [\'socks\'] }\nFlask = \'*\'\n\n\n'
-                    '[dev-packages]\nclick = \'*\'\n')
+                    '[dev-packages]\nclick = \'*\'\nDjango = \'*\'\n')
         proj._pipfile_location = 'test_remove_from_pipfile/Pipfile'
 
         # Confirm initial state of Pipfile.
         p = proj.parsed_pipfile
         assert list(p['packages'].keys()) == ['requests', 'Flask']
-        assert list(p['dev-packages'].keys()) == ['click']
+        assert list(p['dev-packages'].keys()) == ['click', 'Django']
 
         # Remove requests from packages and click from dev-packages.
         proj.remove_package_from_pipfile('requests')
         proj.remove_package_from_pipfile('click', dev=True)
+        proj.remove_package_from_pipfile('DJANGO', dev=True)
         p = proj.parsed_pipfile
 
         # Cleanup test space.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -83,6 +83,12 @@ class TestUtils:
         dep = pipenv.utils.convert_deps_from_pip(dep)
         assert dep == {'MyProject': {'hg': 'http://hg.myproject.org/MyProject', 'ref': 'da39a3ee5e6b'}}
 
+        # vcs dependency without #egg
+        dep = 'git+https://github.com/kennethreitz/requests.git'
+        with pytest.raises(ValueError) as e:
+            dep = pipenv.utils.convert_deps_from_pip(dep)
+            assert 'pipenv requires an #egg fragment for vcs' in str(e)
+
 
     @pytest.mark.parametrize('version, specified_ver, expected', [
         ('*', '*', True),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -99,3 +99,34 @@ class TestUtils:
     ])
     def test_is_required_version(self, version, specified_ver, expected):
         assert pipenv.utils.is_required_version(version, specified_ver) is expected
+
+
+    @pytest.mark.parametrize('entry, expected', [
+        ({'git': 'package.git', 'ref': 'v0.0.1'}, True),
+        ({'hg': 'https://package.com/package', 'ref': 'v1.2.3'}, True),
+        ('*', False),
+        ({'some_value': 5, 'other_value': object()}, False),
+        ('package', False)
+    ])
+    def test_is_vcs(self, entry, expected):
+        assert pipenv.utils.is_vcs(entry) is expected
+
+
+    def test_split_vcs(self):
+        pipfile_dict = {
+                        'packages': {
+                            'requests': {'git': 'https://github.com/kennethreitz/requests.git'},
+                            'Flask': '*'
+                        },
+                        'dev-packages': {
+                            'Django': '==1.10',
+                            'click': {'svn': 'https://svn.notareal.com/click'},
+                            'crayons': {'hg': 'https://hg.alsonotreal.com/crayons'}
+                        }}
+        split_dict = pipenv.utils.split_vcs(pipfile_dict)
+
+        assert list(split_dict['packages'].keys()) == ['Flask']
+        assert split_dict['packages-vcs'] == {'requests': {'git': 'https://github.com/kennethreitz/requests.git'}}
+        assert list(split_dict['dev-packages'].keys()) == ['Django']
+        assert 'click' in split_dict['dev-packages-vcs']
+        assert 'crayons' in split_dict['dev-packages-vcs']


### PR DESCRIPTION
~This is **DO NOT MERGE** until at least later today. Still need to find some time to clean up but want to allow some time for review from anyone who's interested.~

This is an attempt to address #204, #229 and #240 which all have the same underlying issue. When dealing with Pipfile and Pipfile.lock entries we've had a lot of issues with casing and name formatting in comparisons. We'd fixed this previously for package names specified by us, or pipenv users, but missed the case with mis-cased names in other packages' `install_requires` lists.

In order to prevent this from occurring in the future, I've transitioned to using a normalized naming scheme derived from pep426 where all names will be lower-cased and use dashes in place of underscores. This should allow uniform comparison and then we will rewrite the file after passing it through `proper_case` on the way out to ensure "pretty" package names.

This fixes part of the VCS problem but exposed another. We currently require hashes for ALL dependencies which pip can't support for packages that aren't hosted on PyPI. Due to this requirement, we will now split vcs dependencies off from PyPI packages before install to keep things working correctly.

This still has a few cosmetic/organization changes that need to be made, along with some testing for the new functions, but this "works" right now. If anyone has comments or wants to test this out you can clone the repository, run `git fetch origin pull/242/head:fix_vcs_dependencies`, and checkout the branch `fix_vcs_dependencies`.