### PR TITLE
Only spawn shell once

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -868,6 +868,10 @@ def shell(three=None, python=False, compat=False, shell_args=None):
     # Ensure that virtualenv is available.
     ensure_project(three=three, python=python, validate=False)
 
+    if 'PIPENV_ACTIVE' in os.environ:
+        click.echo(crayons.yellow('Shell already activated. No action taken to avoid nested environments.'))
+        return
+
     # Set an environment variable, so we know we're in the environment.
     os.environ['PIPENV_ACTIVE'] = '1'
 


### PR DESCRIPTION
This addresses #239, and will place a restriction on shell creation with a maximum depth of 1 in the CLI. There doesn't seem to be a compelling reason for why a user would want to activate the virtualenv inside of itself, and this behaviour is causing issues for some users. pipenv will now simply print a message saying the shell is already activated and take no action.