### PR TITLE
Add sort_keys param to sort lockfile

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -440,7 +440,7 @@ def do_lock():
 
     # Write out lockfile.
     with open(project.lockfile_location, 'w') as f:
-        f.write(json.dumps(lockfile, indent=4, separators=(',', ': ')))
+        json.dump(lockfile, f, indent=4, separators=(',', ': '), sort_keys=True)
 
     # Purge the virtualenv download dir, for next time.
     with spinner():


### PR DESCRIPTION
When I run pip update, a lot of requirements change position in lock file. 
It hard to understood, which packages updates and in git comes lot of unnecessary changes.