### PR TITLE
add --ignore-hashes support

### DIFF
--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -81,7 +81,7 @@ def convert_deps_to_pip(deps, r=True):
     for dep in deps.keys():
 
         # Default (e.g. '>1.10').
-        extra = deps[dep]
+        extra = deps[dep] if isinstance(deps[dep], str) else ''
         version = ''
 
         # Get rid of '*'.


### PR DESCRIPTION
This will add the `--ignore-hashes` option to `pipenv install` which will allow the user to ignore package hash checking.

The implementation is a little funkier than I wanted, but if you include hashes anywhere in a requirements.txt file, it will require them for everything. This now requires us to purge all hashes read in from the Pipfile.lock before trying to install.