### PR TITLE
Fix redundant '--python' warning on Windows

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -344,15 +344,13 @@ def do_create_virtualenv(three=None, python=None):
     # Pass a Python version to virtualenv, if needed.
     if python:
         click.echo('{0} {1} {2}'.format(crayons.yellow('Using'), crayons.red(python), crayons.yellow('to create virtualenv...')))
-    elif three is False:
-        python = 'python2'
-    elif three is True:
-        python = 'python3'
-
-    # Windows!
-    if os.name == 'nt':
-        click.echo('{0} If you are running on Windows, you should use the {1} option instead.'.format(crayons.red('Warning!'), crayons.green('--python')))
-
+    else:
+        if os.name == 'nt':
+            click.echo('{0} If you are running on Windows, you should use the {1} option instead.'.format(crayons.red('Warning!'), crayons.green('--python')))
+        if three is False:
+            python = 'python2'
+        elif three is True:
+            python = 'python3'
     if python:
         cmd = cmd + ['-p', python]
 


### PR DESCRIPTION
The warning about using `--python` on Windows is shown even when `--python` is used:

<img width="785" alt="screen shot 2017-03-12 at 8 29 17 pm" src="https://cloud.githubusercontent.com/assets/939501/23837705/d274636c-0762-11e7-9e0e-3153335d62ef.png">
