### PR TITLE
Handle rm when missing Pipfile

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -3,7 +3,6 @@ import contextlib
 import codecs
 import json
 import os
-import re
 import sys
 import distutils.spawn
 import shutil

--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -1020,12 +1020,12 @@ def check(three=None, python=False):
     # Assert each specified requirement.
     for marker, specifier in p.data['_meta']['requires'].items():
 
-            if marker in results:
-                try:
-                    assert results[marker] == specifier
-                except AssertionError:
-                    failed = True
-                    click.echo('Specifier {0} does not match {1} ({2}).'.format(crayons.green(marker), crayons.blue(specifier), crayons.red(results[marker])))
+        if marker in results:
+            try:
+                assert results[marker] == specifier
+            except AssertionError:
+                failed = True
+                click.echo('Specifier {0} does not match {1} ({2}).'.format(crayons.green(marker), crayons.blue(specifier), crayons.red(results[marker])))
     if failed:
         click.echo(crayons.red('Failed!'))
         sys.exit(1)

--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -704,6 +704,10 @@ def cli(ctx, where=False, venv=False, rm=False, bare=False, three=False, python=
             do_where(bare=bare)
             sys.exit(0)
 
+        if not project.pipfile_exists:
+            click.echo(crayons.red('No Pipfile found.'), err=True)
+            sys.exit(1)
+
         # --venv was passed...
         elif venv:
 
@@ -720,9 +724,6 @@ def cli(ctx, where=False, venv=False, rm=False, bare=False, three=False, python=
 
         # --rm was passed...
         elif rm:
-            if not project.pipfile_exists:
-                click.echo(crayons.red('No Pipfile found.'), err=True)
-                sys.exit(1)
 
             with spinner():
                 loc = project.virtualenv_location

--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -720,6 +720,9 @@ def cli(ctx, where=False, venv=False, rm=False, bare=False, three=False, python=
 
         # --rm was passed...
         elif rm:
+            if not project.pipfile_exists:
+                click.echo(crayons.red('No Pipfile found.'), err=True)
+                sys.exit(1)
 
             with spinner():
                 loc = project.virtualenv_location


### PR DESCRIPTION
Fixes #283 

@nateprewitt thanks for the guidance on this issue. I've got a small PR here to add an explicit error message (first two commits are just cleanups of a couple things my linter caught).

"No Pipfile found" sounds a little terse to me, so if you have any suggestions for phrasing, I'd be happy to hear them.