### PR TITLE
enforce explicit version specifications in Pipfile

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -398,7 +398,7 @@ def parse_download_fname(fname, name):
 def get_downloads_info(names_map, section):
     info = []
 
-    p = project.parsed_pipfile
+    p = project._pipfile
 
     for fname in os.listdir(project.download_location):
         # Get name from filename mapping.

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -7,6 +7,8 @@ import requests
 import requirements
 import six
 
+from pkg_resources import parse_version
+
 try:
     from HTMLParser import HTMLParser
 except ImportError:
@@ -156,8 +158,24 @@ def is_required_version(version, specified_version):
     # Certain packages may be defined with multiple values.
     if isinstance(specified_version, dict):
         specified_version = specified_version.get('version', '')
+
+    # Separate qualifier (==, <=, etc) from version number.
+    spec_ver = multi_split(specified_version, '=<>') or ['']
+
+    # Parse out version for comparison.
+    parsed_ver = parse_version(version)
+    parsed_spec_ver = parse_version(spec_ver.pop(0))
+
     if specified_version.startswith('=='):
-        return version.strip() == specified_version.split('==')[1].strip()
+        return parsed_ver == parsed_spec_ver
+    elif specified_version.startswith('>='):
+        return parsed_ver >= parsed_spec_ver
+    elif specified_version.startswith('>'):
+        return parsed_ver > parsed_spec_ver
+    elif specified_version.startswith('<='):
+        return parsed_ver <= parsed_spec_ver
+    elif specified_version.startswith('<'):
+        return parsed_ver < parsed_spec_ver
     return True
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -99,8 +99,12 @@ class TestUtils:
         ('*', '*', True),
         ('2.1.6', '==2.1.4', False),
         ('20160913', '>=20140815', True),
+        ('20160913', '<=20140815', False),
+        ('2016.09.13', '<2016.09.13', False),
         ('1.4', {'svn': 'svn://svn.myproj.org/svn/MyProj', 'version': '==1.4'}, True),
-        ('2.13.0', {'extras': ['socks'], 'version': '==2.12.4'}, False)
+        ('2.13.0', {'extras': ['socks'], 'version': '==2.12.4'}, False),
+        ('1.6', {'extras': ['extra_thing']}, True),
+        ('', '', True)
     ])
     def test_is_required_version(self, version, specified_ver, expected):
         assert pipenv.utils.is_required_version(version, specified_ver) is expected


### PR DESCRIPTION
This should address #298 with a more robust version checking system. If a user specifies a requirement directly in the Pipfile (`Django<1.11.0`), Pipenv will now only add requirements to the Pipfile.lock that meet that spec. This will prevent dependencies of other packages from overwriting the explicit version in the Pipfile.