### PR TITLE
strip implicit post releases from version numbers in Pipfile.lock

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -392,6 +392,10 @@ def parse_download_fname(fname, name):
     # Substring out package name (plus dash) from file name to get version.
     version = fname[len(name)+1:]
 
+    # Ignore implicit post releases in version number.
+    if '-' in version and version.split('-')[1].isdigit():
+        version = version.split('-')[0]
+
     return version
 
 

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -14,11 +14,11 @@ from pipenv.project import Project
 class TestPipenv():
 
     @pytest.mark.parametrize('fname, name, expected', [
-        ('functools32-3.2.3-2.zip', 'functools32', '3.2.3-2'),
+        ('functools32-3.2.3-2.zip', 'functools32', '3.2.3'),
         ('functools32-3.2.3-blah.zip', 'functools32', '3.2.3-blah'),
         ('functools32-3.2.3.zip', 'functools32', '3.2.3'),
         ('colorama-0.3.7-py2.py3-none-any.whl', 'colorama', '0.3.7'),
-        ('colorama-0.3.7-2-py2.py3-none-any.whl', 'colorama', '0.3.7-2'),
+        ('colorama-0.3.7-2-py2.py3-none-any.whl', 'colorama', '0.3.7'),
         ('click-completion-0.2.1.tar.gz', 'click-completion', '0.2.1'),
         ('Twisted-16.5.0.tar.bz2', 'Twisted', '16.5.0'),
         ('Twisted-16.1.1-cp27-none-win_amd64.whl', 'twIsteD', '16.1.1'),


### PR DESCRIPTION
Alright, so after sitting on this for a month, I think I'm ready to pull the trigger on this. This PR addresses #270 by stripping "[implicit post release](https://www.python.org/dev/peps/pep-0440/#implicit-post-releases)" data out of the version number. This information, while important, seems to be handled under the hood by `pip`. Passing a version number with the implicit post release directly to `pip` doesn't work, so the reasonable option here seems to be removing it and allowing `pip` to give us the most recent post release.