### PR TITLE
remove package from all locations in Pipfile

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -849,10 +849,9 @@ def uninstall(package_name=False, more_packages=False, three=None, python=False,
 
     # Un-install all dependencies, if --all was provided.
     if all is True:
-        if not dev:
-            click.echo(crayons.yellow('Un-installing all packages from virtualenv...'))
-            do_purge(allow_global=system)
-            sys.exit(0)
+        click.echo(crayons.yellow('Un-installing all packages from virtualenv...'))
+        do_purge(allow_global=system)
+        sys.exit(0)
 
     # Uninstall [dev-packages], if --dev was provided.
     if dev:
@@ -876,12 +875,16 @@ def uninstall(package_name=False, more_packages=False, three=None, python=False,
         click.echo(crayons.blue(c.out))
 
         if pipfile_remove:
-            if dev:
-                click.echo('Removing {0} from Pipfile\'s {1}...'.format(crayons.green(package_name), crayons.red('[dev-packages]')))
+            norm_name = pep426_name(package_name)
+            if norm_name in project._pipfile['dev-packages'] or norm_name in project._pipfile['packages']:
+                click.echo('Removing {0} from Pipfile...'.format(crayons.green(package_name)))
             else:
-                click.echo('Removing {0} from Pipfile\'s {1}...'.format(crayons.green(package_name), crayons.red('[packages]')))
+                click.echo('No package {0} to remove from Pipfile.'.format(crayons.green(package_name)))
+                continue
 
-            project.remove_package_from_pipfile(package_name, dev)
+            # Remove package from both packages and dev-packages.
+            project.remove_package_from_pipfile(package_name, dev=True)
+            project.remove_package_from_pipfile(package_name, dev=False)
 
         if lock:
             do_lock(no_hashes=no_hashes)


### PR DESCRIPTION
This is a follow up to https://github.com/kennethreitz/pipenv/issues/208#issuecomment-296668612, which aptly points out we've had a broken uninstall command for `dev-packages` for some time.

The semantics that were defined for `--dev` is that it uninstalls every package listed in `[dev-packages]` without removing them from the Pipfile. In order to remove a package the user *should* have been able to use `pipenv uninstall package_name` but that hasn't been working.

Since we don't have a way to specify where the package exists in the Pipfile, `pipenv uninstall package_name` should probably remove `package_name` from both `[packages]` and `[dev-packages]` for consistency. Having a different/conflicting dependency for `packages` vs `dev-packages` doesn't really make sense, so in theory it should only appear in one section.

I'm not convinced this is the best way to handle this, but it's consistent with what we've defined in the past. @kennethreitz, any further thoughts on current uninstall design?