### PR TITLE
get python version from Pipfile's requires

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -386,6 +386,16 @@ def parse_install_output(output):
     return names
 
 
+def get_python_from_requires():
+    python_version = project.parsed_pipfile.get('requires', {}).get('python_version')
+
+    if python_version:
+        for path in os.environ["PATH"].split(os.pathsep):
+            executable = os.path.join(path, "python%s" % python_version[:3])
+            if os.path.exists(executable) and os.access(executable, os.X_OK):
+                return executable
+
+
 def do_create_virtualenv(three=None, python=None):
     """Creates a virtualenv."""
     click.echo(crayons.yellow('Creating a virtualenv for this project...'), err=True)
@@ -407,6 +417,8 @@ def do_create_virtualenv(three=None, python=None):
             python = 'python2'
         elif three is True:
             python = 'python3'
+        else:
+            python = get_python_from_requires()
     if python:
         cmd = cmd + ['-p', python]
 


### PR DESCRIPTION
It's a first draft of feature described here https://github.com/kennethreitz/pipenv/issues/286.

When there's no python version (or --two/--three) specified it tries to figure out the python version based on python_version from [requires] section (pep508).

The match is simple, gets only first 3 chars (like 2.7 or 3.5) from python version and tries to find python executable for that version.

If it's not found - the behaviour is exactly the same as previous.