### PR TITLE
hash Pipfile and Pipfile.lock content instead of path

### DIFF
--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -63,10 +63,10 @@ class Project(object):
         #   http://www.tldp.org/LDP/abs/html/special-chars.html#FIELDREF
         #   https://github.com/torvalds/linux/blob/2bfe01ef/include/uapi/linux/binfmts.h#L18
         sanitized = re.sub(r'[ $`!*@"\\\r\n\t]', '_', self.name)[0:42]
+        encoded_hash = hashlib.sha256(open(self.pipfile_location).read().encode()).hexdigest()[:6]
 
-        # Hash the full path of the pipfile
-        hash = hashlib.sha256(self.pipfile_location.encode()).digest()[:6]
-        encoded_hash = base64.urlsafe_b64encode(hash).decode()
+        if self.lockfile_exists:
+            encoded_hash += hashlib.sha256(open(self.lockfile_location).read().encode()).hexdigest()[:6]
 
         # If the pipfile was located at '/home/user/MY_PROJECT/Pipfile',
         # the name of its virtualenv will be 'my-project-wyUfYPqE'


### PR DESCRIPTION
I think it's better to include the Pipfile and Pipfile.lock hash instead of path hash in the virtualenv name.

It will prevent of re-creating the virtualenv when just moved the project and it will also "cache" the virtualenv for different Pipfiles.

It's quite useful when having multiple branches with different dependencies - don't need to re-install the virtualenv everytime and it will use correct virtualenv just after switch.

Another use case is having multiple projects with the same dependencies (for example multiple projects which require just ansible), they can safely share the same virtualenv when Pipfile.lock is the same.

It will also massively improve build time on CI runs when WORKON_HOME is shared across builds.