### PR TITLE
Fix for key error when uninstalling [dev-]packages

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -906,7 +906,7 @@ def uninstall(package_name=False, more_packages=False, three=None, python=False,
 
         if pipfile_remove:
             norm_name = pep423_name(package_name)
-            if norm_name in project._pipfile['dev-packages'] or norm_name in project._pipfile['packages']:
+            if norm_name in project._pipfile.get('dev-packages', {}) or norm_name in project._pipfile.get('packages', {}):
                 click.echo('Removing {0} from Pipfile...'.format(crayons.green(package_name)))
             else:
                 click.echo('No package {0} to remove from Pipfile.'.format(crayons.green(package_name)))


### PR DESCRIPTION
When a user tries to uninstall a package from `packages`, the `dev-packages` key throws a `KeyError` in the `_pipfile` OrderedDict if they have never installed a dev package. This could be the case for new users of Pipenv who are just trying out PoCs rather than full-fledged projects. This PR fixes this.

Similarly, if a user tries to `pipenv uninstall <package>` without ever installing that package, the `packages` key throws a `KeyError`. While this is unintended usage, the user would still see a stack trace and this manifests as poor workmanship, hence fixing that too.