### PR TITLE
handle package[extra]==version properly

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,6 +41,11 @@ class TestUtils:
         deps = pipenv.utils.convert_deps_to_pip(deps, r=False)
         assert deps[0] == 'django>1.10'
 
+        # Pinned version with Extras
+        deps = {'requests': {'extras': ['socks'], 'version': '>1.10'}}
+        deps = pipenv.utils.convert_deps_to_pip(deps, r=False)
+        assert deps[0] == 'requests[socks]>1.10'
+
         # pinax = { git = 'git://github.com/pinax/pinax.git', ref = '1.4', editable = true }
         deps = {'pinax': {'git': 'git://github.com/pinax/pinax.git', 'ref': '1.4', 'editable': True}}
         deps = pipenv.utils.convert_deps_to_pip(deps, r=False)
@@ -55,6 +60,11 @@ class TestUtils:
         deps = {'FooProject': {'version': '==1.2', 'hash': 'sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824'}}
         deps = pipenv.utils.convert_deps_to_pip(deps, r=False)
         assert deps[0] == 'FooProject==1.2 --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824'
+
+        # test everything
+        deps = {'FooProject': {'version': '==1.2', 'extras': ['stuff'], 'hash': 'sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824'}}
+        deps = pipenv.utils.convert_deps_to_pip(deps, r=False)
+        assert deps[0] == 'FooProject[stuff]==1.2 --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824'
 
         # test unicode values
         deps = {u'django': u'==1.10'}
@@ -78,6 +88,11 @@ class TestUtils:
         dep = 'requests[socks]'
         dep = pipenv.utils.convert_deps_from_pip(dep)
         assert dep == {'requests': {'extras': ['socks']}}
+
+        # requests[socks] w/ version
+        dep = 'requests[socks]==1.10'
+        dep = pipenv.utils.convert_deps_from_pip(dep)
+        assert dep == {'requests': {'extras': ['socks'], 'version': '==1.10'}}
 
         dep = '-e svn+svn://svn.myproject.org/svn/MyProject#egg=MyProject'
         dep = pipenv.utils.convert_deps_from_pip(dep)


### PR DESCRIPTION
Previously doing `pipenv install "django-rest-auth[with_social]==0.8.2` would
lose the extra information and if you edited the Pipfile by hand to
```
[[source]]
url = "https://pypi.python.org/simple"
verify_ssl = true

[packages.django-rest-auth]
version = "==0.8.2"
extras = [ "with_social",]
```

`pipenv update` would break with a malformed pip command.