### PR TITLE
Use sys.path.insert(1, v_path) instead of sys.path.append(v_path)

### DIFF
--- a/pipenv/__init__.py
+++ b/pipenv/__init__.py
@@ -8,7 +8,7 @@ import sys
 
 # Inject vendored directory into system path.
 v_path = os.path.sep.join([os.path.dirname(os.path.realpath(__file__)), 'vendor'])
-sys.path.append(v_path)
+sys.path.insert(1, v_path)
 
 
 from .cli import cli


### PR DESCRIPTION
Packages under `pipenv/vendor` should be used than that installed by pip.

This will resolve package conflict issues like https://github.com/kennethreitz/pipenv/issues/355.

`pipenv/vendor`  will be inserted into `sys.path` after the script directory.

cf. https://docs.python.org/3/library/sys.html#sys.path, http://stackoverflow.com/a/10097543

## Before

```console
$ pip3 install click==0.4
$ pipenv
Traceback (most recent call last):
  File "/usr/local/bin/pipenv", line 11, in <module>
    load_entry_point('pipenv==4.0.1', 'console_scripts', 'pipenv')()
  File "/usr/local/lib/python3.5/dist-packages/pkg_resources/__init__.py", line 560, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/local/lib/python3.5/dist-packages/pkg_resources/__init__.py", line 2648, in load_entry_point
    return ep.load()
  File "/usr/local/lib/python3.5/dist-packages/pkg_resources/__init__.py", line 2302, in load
    return self.resolve()
  File "/usr/local/lib/python3.5/dist-packages/pkg_resources/__init__.py", line 2308, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/local/lib/python3.5/dist-packages/pipenv/__init__.py", line 14, in <module>
    from .cli import cli
  File "/usr/local/lib/python3.5/dist-packages/pipenv/cli.py", line 955, in <module>
    def shell(three=None, python=False, compat=False, shell_args=None):
  File "/usr/local/lib/python3.5/dist-packages/click/decorators.py", line 108, in decorator
    return _make_command(f, name, attrs, cls)
  File "/usr/local/lib/python3.5/dist-packages/click/decorators.py", line 82, in _make_command
    callback=f, params=params, **attrs)
TypeError: __init__() got an unexpected keyword argument 'context_settings'
zsh: exit 1     pipenv
```

## After

```
$ pip3 install click==0.4
$ pipenv
Usage: pipenv [OPTIONS] COMMAND [ARGS]...

Options:
  --where          Output project home information.
  --venv           Output virtualenv information.
  --rm             Remove the virtualenv.
...
```

