### PR TITLE
Import slow modules lazily

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -17,7 +17,6 @@ import pexpect
 import requests
 import pipfile
 from blindspin import spinner
-from pip.req.req_file import parse_requirements
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
 from .project import Project
@@ -104,6 +103,7 @@ def ensure_pipfile(validate=True):
             # Parse requirements.txt file with Pip's parser.
             # Pip requires a `PipSession` which is a subclass of requests.Session.
             # Since we're not making any network calls, it's initialized to nothing.
+            from pip.req.req_file import parse_requirements
             reqs = [r.req for r in parse_requirements(project.requirements_location, session='')]
 
             for package in reqs:

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -4,7 +4,6 @@ import tempfile
 
 import parse
 import requests
-import requirements
 import six
 
 # List of version control systems we support.
@@ -36,6 +35,7 @@ def convert_deps_from_pip(dep):
     """"Converts a pip-formatted dependency to a Pipfile-formatted one."""
     dependency = {}
 
+    import requirements
     req = [r for r in requirements.parse(dep)][0]
 
     # VCS Installs.


### PR DESCRIPTION
This pr makes pipenv launching faster by lazy import modules which wastes much time for initialize.

This is the part of [pprofile](https://github.com/vpelletier/pprofile) result by running `$ pprofile -m pipenv`. `import parse_requirements` wastes over half of all initialize time, `import requirements` wastes about 18%, ( and `import requests` wastes 14% ).

```
File: /tmp/pipenv/pipenv/cli.py
File duration: 0.0026648s (0.03%)
Line #|      Hits|         Time| Time per hit|      %|Source code
------+----------+-------------+-------------+-------+-----------
     1|         0|            0|            0|  0.00%|# -*- coding: utf-8 -*-
     2|         2|  1.50204e-05|  7.51019e-06|  0.00%|import contextlib
     3|         1|  4.76837e-06|  4.76837e-06|  0.00%|import codecs
     4|         1|  2.36034e-05|  2.36034e-05|  0.00%|import json
(call)|         1|    0.0673194|    0.0673194|  0.71%|# <frozen importlib._bootstrap>:966 _find_and_load
     5|         1|  1.95503e-05|  1.95503e-05|  0.00%|import os
     6|         1|  5.48363e-06|  5.48363e-06|  0.00%|import sys
     7|         1|  1.69277e-05|  1.69277e-05|  0.00%|import distutils.spawn
(call)|         1|     0.194684|     0.194684|  2.07%|# <frozen importlib._bootstrap>:966 _find_and_load
     8|         1|  7.39098e-06|  7.39098e-06|  0.00%|import shutil
     9|         1|  2.86102e-05|  2.86102e-05|  0.00%|import signal
(call)|         1|    0.0355198|    0.0355198|  0.38%|# <frozen importlib._bootstrap>:966 _find_and_load
    10|         0|            0|            0|  0.00%|
    11|         1|  3.17097e-05|  3.17097e-05|  0.00%|import click
(call)|         1|    0.0555232|    0.0555232|  0.59%|# <frozen importlib._bootstrap>:966 _find_and_load
    12|         1|  3.12328e-05|  3.12328e-05|  0.00%|import click_completion
(call)|         1|     0.275809|     0.275809|  2.93%|# <frozen importlib._bootstrap>:966 _find_and_load
    13|         1|  1.90735e-05|  1.90735e-05|  0.00%|import crayons
(call)|         1|    0.0660694|    0.0660694|  0.70%|# <frozen importlib._bootstrap>:966 _find_and_load
    14|         1|  2.00272e-05|  2.00272e-05|  0.00%|import delegator
(call)|         1|    0.0750365|    0.0750365|  0.80%|# <frozen importlib._bootstrap>:966 _find_and_load
    15|         1|  2.76566e-05|  2.76566e-05|  0.00%|import parse
(call)|         1|    0.0546319|    0.0546319|  0.58%|# <frozen importlib._bootstrap>:966 _find_and_load
    16|         1|  1.45435e-05|  1.45435e-05|  0.00%|import pexpect
    17|         1|   2.3365e-05|   2.3365e-05|  0.00%|import requests
(call)|         1|      1.37504|      1.37504| 14.60%|# <frozen importlib._bootstrap>:966 _find_and_load
    18|         1|  2.09808e-05|  2.09808e-05|  0.00%|import pipfile
(call)|         1|    0.0498064|    0.0498064|  0.53%|# <frozen importlib._bootstrap>:966 _find_and_load
    19|         1|  2.74181e-05|  2.74181e-05|  0.00%|from blindspin import spinner
(call)|         1|  2.83718e-05|  2.83718e-05|  0.00%|# <frozen importlib._bootstrap>:996 _handle_fromlist
(call)|         1|   0.00350451|   0.00350451|  0.04%|# <frozen importlib._bootstrap>:966 _find_and_load
    20|         1|  2.74181e-05|  2.74181e-05|  0.00%|from pip.req.req_file import parse_requirements
(call)|         1|  1.62125e-05|  1.62125e-05|  0.00%|# <frozen importlib._bootstrap>:996 _handle_fromlist
(call)|         1|      5.34429|      5.34429| 56.73%|# <frozen importlib._bootstrap>:966 _find_and_load
    21|         1|  2.21729e-05|  2.21729e-05|  0.00%|from requests.packages.urllib3.exceptions import InsecureRequestWarning
(call)|         1|  1.21593e-05|  1.21593e-05|  0.00%|# <frozen importlib._bootstrap>:996 _handle_fromlist
    22|         0|            0|            0|  0.00%|
    23|         1|  2.88486e-05|  2.88486e-05|  0.00%|from .project import Project
(call)|         1|  1.33514e-05|  1.33514e-05|  0.00%|# <frozen importlib._bootstrap>:996 _handle_fromlist
(call)|         1|      1.73377|      1.73377| 18.40%|# <frozen importlib._bootstrap>:966 _find_and_load
    24|         1|  1.83582e-05|  1.83582e-05|  0.00%|from .utils import (convert_deps_from_pip, convert_deps_to_pip, is_required_version,
(call)|         1|  1.19209e-05|  1.19209e-05|  0.00%|# <frozen importlib._bootstrap>:996 _handle_fromlist
    25|         0|            0|            0|  0.00%|    proper_case, pep423_name, split_vcs, recase_file)
    26|         1|   4.3869e-05|   4.3869e-05|  0.00%|from .__version__ import __version__
(call)|         1|  1.28746e-05|  1.28746e-05|  0.00%|# <frozen importlib._bootstrap>:996 _handle_fromlist
(call)|         1|   0.00255609|   0.00255609|  0.03%|# <frozen importlib._bootstrap>:966 _find_and_load
    27|         1|  3.57628e-05|  3.57628e-05|  0.00%|from . import pep508checker, progress
(call)|         1|  0.000144482|  0.000144482|  0.00%|# <frozen importlib._bootstrap>:195 _lock_unlock_module
(call)|         1|    0.0109942|    0.0109942|  0.12%|# <frozen importlib._bootstrap>:996 _handle_fromlist
    28|         1|  2.19345e-05|  2.19345e-05|  0.00%|from .environments import PIPENV_COLORBLIND, PIPENV_NOSPIN, PIPENV_SHELL_COMPAT, PIPENV_VENV_IN_PROJECT
(call)|         1|  1.38283e-05|  1.38283e-05|  0.00%|# <frozen importlib._bootstrap>:996 _handle_fromlist
    29|         0|            0|            0|  0.00%|
    30|         0|            0|            0|  0.00%|# Backport required for earlier versions of Python.
    31|         1|  5.96046e-06|  5.96046e-06|  0.00%|if sys.version_info < (3, 3):
    32|         0|            0|            0|  0.00%|    from backports.shutil_get_terminal_size import get_terminal_size
    33|         0|            0|            0|  0.00%|else:
    ...

File: /tmp/pipenv/pipenv/utils.py
File duration: 0.000172615s (0.00%)
Line #|      Hits|         Time| Time per hit|      %|Source code
------+----------+-------------+-------------+-------+-----------
     1|         0|            0|            0|  0.00%|# -*- coding: utf-8 -*-
     2|         2|  1.54972e-05|   7.7486e-06|  0.00%|import os
     3|         1|  5.96046e-06|  5.96046e-06|  0.00%|import tempfile
     4|         0|            0|            0|  0.00%|
     5|         1|  6.19888e-06|  6.19888e-06|  0.00%|import parse
     6|         1|  5.96046e-06|  5.96046e-06|  0.00%|import requests
     7|         1|   1.5974e-05|   1.5974e-05|  0.00%|import requirements
(call)|         1|      1.71513|      1.71513| 18.21%|# <frozen importlib._bootstrap>:966 _find_and_load
     8|         1|  8.58307e-06|  8.58307e-06|  0.00%|import six
     9|         0|            0|            0|  0.00%|
    10|         1|  4.29153e-06|  4.29153e-06|  0.00%|try:
    11|         1|  1.64509e-05|  1.64509e-05|  0.00%|    from HTMLParser import HTMLParser
(call)|         1|    0.0069468|    0.0069468|  0.07%|# <frozen importlib._bootstrap>:966 _find_and_load
    12|         1|  5.72205e-06|  5.72205e-06|  0.00%|except ImportError:
    13|         1|  1.74046e-05|  1.74046e-05|  0.00%|    from html.parser import HTMLParser
(call)|         1|  1.93119e-05|  1.93119e-05|  0.00%|# <frozen importlib._bootstrap>:996 _handle_fromlist
    14|         0|            0|            0|  0.00%|
    15|         0|            0|            0|  0.00%|# List of version control systems we support.
    16|         1|  5.48363e-06|  5.48363e-06|  0.00%|VCS_LIST = ('git', 'svn', 'hg', 'bzr')
    ...
```

Because `parse_requirements` and `requirements` are used only once, I changed import position.

## before

```
$ time pipenv
...
pipenv  0.50s user 0.05s system 99% cpu 0.552 total
```

## after 

```
$ time python3 -m pipenv
...
python3 -m pipenv  0.16s user 0.02s system 95% cpu 0.188 total
```