### PR TITLE
Simply Dependency Installation

### DIFF
--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,6 +1,3 @@
-from hashlib import sha256
-from base64 import urlsafe_b64encode
-
 import delegator
 
 import pipenv.project
@@ -10,13 +7,9 @@ class TestProject():
 
     def test_project(self):
         proj = pipenv.project.Project()
-        hash = urlsafe_b64encode(
-            sha256(proj.pipfile_location.encode()).digest()[:6]).decode()
 
-        # assert proj.name == 'pipenv'
         assert proj.pipfile_exists
         assert proj.virtualenv_exists
-        # assert proj.virtualenv_name == 'pipenv-' + hash
 
     def test_proper_names(self):
         proj = pipenv.project.Project()


### PR DESCRIPTION
This will drastically reduce the amount of duplicated code for our installs now that we're performing all of them one at a time. The previous approach had required two separate conditionals due to hashes. Since we can apply require hashes on a package-by-package basis now, this division is no longer needed.

It's possible we can remove this all the way up into the Pipfile, but I haven't confirmed that yet. This patch will allow us to fix #377 and we work towards further removal in a future patch.