### PR TITLE
Fix for SSLError: cacert.pem missing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,4 +73,5 @@ setup(
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy'
     ],
+    include_package_data=True,
 )


### PR DESCRIPTION
The file `cacert.pem` was never included in wheels because the setuptools flag `include_package_data=True` wasn't set, causing issue #396.

This PR fixes that.

I don't know where you're trying to go with future versions, as your `pipenv/vendors` directory is almost empty now. So I have based this branch on the `v5.1.2` tag.