### PR TITLE
Fixed handling of .py files on Windows

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -731,10 +731,11 @@ def pip_download(package_name):
 
 
 def which(command):
-    if os.name == 'nt' and not command.endswith('.py'):
+    if os.name == 'nt':
+        if command.endswith('.py'):
+            return os.sep.join([project.virtualenv_location] + ['Scripts\{0}'.format(command)])
         return os.sep.join([project.virtualenv_location] + ['Scripts\{0}.exe'.format(command)])
-    else:
-        return os.sep.join([project.virtualenv_location] + ['bin/{0}'.format(command)])
+    return os.sep.join([project.virtualenv_location] + ['bin/{0}'.format(command)])
 
 
 def which_pip(allow_global=False):


### PR DESCRIPTION
`pipenv shell` on Windows throws a FileNotFoundException due to `which('activate_this.py')` returning a path containing a forward slash:

```
Traceback (most recent call last):
  File "c:\python36\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "c:\python36\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Python36\Scripts\pipenv.exe\__main__.py", line 9, in <module>
  File "c:\python36\lib\site-packages\pipenv\vendor\click\core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "c:\python36\lib\site-packages\pipenv\vendor\click\core.py", line 697, in main
    rv = self.invoke(ctx)
  File "c:\python36\lib\site-packages\pipenv\vendor\click\core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "c:\python36\lib\site-packages\pipenv\vendor\click\core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "c:\python36\lib\site-packages\pipenv\vendor\click\core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "c:\python36\lib\site-packages\pipenv\cli.py", line 1057, in shell
    with open(activate_this) as f:
FileNotFoundError: [Errno 2] No such file or directory: 'C:\\Users\\EmberQuill\\.virtualenvs\\website-z1bUap_x\\bin/activate_this.py'
```

This should fix it.