### PR TITLE
Force reclone of editable git if url changes

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -738,7 +738,7 @@ def pip_install(package_name=None, r=None, allow_global=False, ignore_hashes=Fal
 
         no_deps = '--no-deps' if no_deps else ''
 
-        pip_command = '"{0}" install {3} {1} -i {2}'.format(which_pip(allow_global=allow_global), install_reqs, source['url'], no_deps)
+        pip_command = '"{0}" install {3} {1} -i {2} --exists-action w'.format(which_pip(allow_global=allow_global), install_reqs, source['url'], no_deps)
 
         if verbose:
             click.echo('$ {0}'.format(pip_command), err=True)


### PR DESCRIPTION
Fixes #484 

If changing url of editable git repo for package, pip doesn't know what to do and asks for input which causes pipenv to crash. This change assumes that we user wants to always prefer package installed as defined in Pipfile, therefore, wiping the existing install and recloning to meet defined requirements.

Testing:
1. Create fresh venv
2. Add following contents of Pipfile
```
[[source]]
verify_ssl = true
url = "https://pypi.python.org/simple"

[packages]
fudge = { git = 'https://github.com/fudge-py/fudge.git', ref = 'master', editable = true }
```
3. `pipenv install` should be successful
4. update Pipfile fudge requirement url to `https://github.com/jsatt/fudge.git`
    * before change, this fails with traceback similar to #484 
    * after change, this succeeds
