### PR TITLE
Automatically set system flag if running command with abs path

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -1279,6 +1279,8 @@ def run(command, args, three=None, python=False, system=False):
     ensure_project(three=three, python=python, validate=False)
 
     _which = 'which' if not os.name == 'nt' else 'where'
+    if command.startswith(os.sep):
+        system = True
     command_path = which(command) if not system else command
 
     if system:


### PR DESCRIPTION
paths starting with the os separator are absolute paths and shouldn't be resolved with the `which` helper and should have the virtualenv activated automatically for them.