### PR TITLE
Leverage pip's requests to allow for error catching

### DIFF
--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -58,7 +58,7 @@ def resolve_deps(deps, sources=None, verbose=False):
 
     pip_options, _ = pip_command.parse_args(pip_args)
 
-    pypi = PyPIRepository(pip_options=pip_options, session=requests)
+    pypi = PyPIRepository(pip_options=pip_options, session=pip._vendor.requests)
 
     if verbose:
         logging.log.verbose = True


### PR DESCRIPTION
I logged the issue here: https://github.com/pypa/pip/issues/4717

Basically, the only thing standing in our way of using a third party private server (gemfury in this case) is that the pip code only catching request errors if you use their session when calling it.

What are your thoughts on this?