### PR TITLE
fix a bug on windows - can not get the python version

### DIFF
--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -28,7 +28,7 @@ def python_version(path_to_python):
 
     try:
         TEMPLATE = 'Python {}.{}.{}'
-        c = delegator.run('{0} --version'.format(path_to_python), block=False)
+        c = delegator.run([path_to_python,'--version'], block=False)
         c.return_code == 0
     except Exception:
         return None


### PR DESCRIPTION
I find a bug on windows.
The program can not get the python version when writing the pipfile.