### PR TITLE
Fix NoneType.

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -1662,8 +1662,20 @@ def check(three=None, python=False):
 @click.command(help=u"Displays currently–installed dependency graph information.")
 @click.option('--bare', is_flag=True, default=False, help="Minimal output.")
 def graph(bare=False):
+    try:
+        python_path = which('python')
+    except AttributeError:
+        puts(
+            u'{0}: {1}'.format(
+                crayons.red('Warning', bold=True),
+                u'Unable to display currently–installed dependency graph information here. '
+                u'Please confirm your execution path.',
+            ), err=True
+        )
+        sys.exit(1)
+
     cmd = '"{0}" {1}'.format(
-        which('python'),
+        python_path,
         shellquote(pipdeptree.__file__.rstrip('cdo'))
     )
 

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -42,6 +42,8 @@ class Project(object):
     @property
     def name(self):
         if self._name is None:
+            if not self.pipfile_exists:
+                exit(1)
             self._name = self.pipfile_location.split(os.sep)[-2]
         return self._name
 

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -42,8 +42,6 @@ class Project(object):
     @property
     def name(self):
         if self._name is None:
-            if not self.pipfile_exists:
-                exit(1)
             self._name = self.pipfile_location.split(os.sep)[-2]
         return self._name
 


### PR DESCRIPTION
Fix this cmd `pipenv graph` executed in system path.
```
$ pipenv graph
Traceback (most recent call last):
  File "/usr/local/bin/pipenv", line 11, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.6/site-packages/pipenv/vendor/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/pipenv/vendor/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.6/site-packages/pipenv/vendor/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.6/site-packages/pipenv/vendor/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/site-packages/pipenv/vendor/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/pipenv/cli.py", line 1666, in graph
    which('python'),
  File "/usr/local/lib/python3.6/site-packages/pipenv/cli.py", line 1045, in which
    p = os.sep.join([project.virtualenv_location] + ['bin/{0}'.format(command)])
  File "/usr/local/lib/python3.6/site-packages/pipenv/project.py", line 111, in virtualenv_location
    c = delegator.run('pew dir "{0}"'.format(self.virtualenv_name))
  File "/usr/local/lib/python3.6/site-packages/pipenv/project.py", line 88, in virtualenv_name
    sanitized = re.sub(r'[ $`!*@"\\\r\n\t]', '_', self.name)[0:42]
  File "/usr/local/lib/python3.6/site-packages/pipenv/project.py", line 45, in name
    self._name = self.pipfile_location.split(os.sep)[-2]
AttributeError: 'NoneType' object has no attribute 'split'
```