### PR TITLE
Output friendly and concise message when updating pipenv failed.

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -140,7 +140,11 @@ def check_for_updates():
 
 def ensure_latest_self(user=False):
     """Updates Pipenv to latest version, cleverly."""
-    r = requests.get('https://pypi.python.org/pypi/pipenv/json', timeout=0.5)
+    try:
+        r = requests.get('https://pypi.python.org/pypi/pipenv/json', timeout=0.5)
+    except requests.RequestException as e:
+        click.echo(crayons.red(e))
+        sys.exit(1)
     latest = sorted([semver.parse_version_info(v) for v in list(r.json()['releases'].keys())])[-1]
     current = semver.parse_version_info(__version__)
 


### PR DESCRIPTION
Updating pipenv might fail occasionally, and the default output is not quite clear.
So I use crayons to beautify the error message and make it more friendly. 

<img width="958" alt="2017-09-15 20 47 25" src="https://user-images.githubusercontent.com/8557100/30483094-2edbd200-99eb-11e7-8abb-fd97e3f9cf28.png">
