### PR TITLE
Support Miniconda's `python --version` format

### DIFF
--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -27,14 +27,17 @@ def python_version(path_to_python):
         return None
 
     try:
-        TEMPLATE = 'Python {}.{}.{}'
         c = delegator.run([path_to_python, '--version'], block=False)
         assert c.return_code == 0
     except Exception:
         return None
-
     output = c.out.strip() or c.err.strip()
-    parsed = parse.parse(TEMPLATE, output).fixed
+    
+    @parse.with_pattern(r'.*')
+    def allow_empty(text):
+        return text
+    TEMPLATE = 'Python {}.{}.{:d}{:AllowEmpty}'
+    parsed = parse.parse(TEMPLATE, output, dict(AllowEmpty=allow_empty)).fixed
 
     return u"{v[0]}.{v[1]}.{v[2]}".format(v=parsed)
 


### PR DESCRIPTION
On Windows, Miniconda's python prints "Python 3.6.2 :: Continuum Analytics, Inc." when running `python --version`