### PR TITLE
Fix popen_spawn when specifying a path on Windows which contains "\" separators

### DIFF
--- a/pipenv/vendor/pexpect/popen_spawn.py
+++ b/pipenv/vendor/pexpect/popen_spawn.py
@@ -40,7 +40,7 @@ class PopenSpawn(SpawnBase):
             kwargs['creationflags'] = subprocess.CREATE_NEW_PROCESS_GROUP
 
         if not isinstance(cmd, (list, tuple)):
-            cmd = shlex.split(cmd)
+            cmd = shlex.split(cmd, posix=sys.platform != 'win32')
 
         self.proc = subprocess.Popen(cmd, **kwargs)
         self.closed = False


### PR DESCRIPTION
I've opened an identical PR for pexpect: https://github.com/pexpect/pexpect/pull/446