### PR TITLE
Relative file paths fix

### DIFF
--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -222,8 +222,8 @@ class Project(object):
     def file_dev_packages(self):
         """Return a list of file packages to make into abspaths in lockfile."""
         files = {}
-        for k, v in self.parsed_pipfile.get('packages', {}).items():
-            if is_file(v):
+        for k, v in self.parsed_pipfile.get('dev-packages', {}).items():
+            if is_file(dict(v)):
                 files.update({k: v})
         return files
 
@@ -231,8 +231,8 @@ class Project(object):
     def file_packages(self):
         """Return a list of dev file packages for making abspaths in lockfile."""
         files = {}
-        for k, v in self.parsed_pipfile.get('dev-packages', {}).items():
-            if is_file(v):
+        for k, v in self.parsed_pipfile.get('packages', {}).items():
+            if is_file(dict(v)):
                 files.update({k: v})
         return files
 
@@ -241,7 +241,7 @@ class Project(object):
         """Returns a list of VCS packages, for not pip-tools to consume."""
         ps = {}
         for k, v in self.parsed_pipfile.get('packages', {}).items():
-            if is_vcs(v):
+            if is_vcs(dict(v)):
                 ps.update({k: v})
         return ps
 
@@ -250,7 +250,7 @@ class Project(object):
         """Returns a list of VCS packages, for not pip-tools to consume."""
         ps = {}
         for k, v in self.parsed_pipfile.get('dev-packages', {}).items():
-            if is_vcs(v):
+            if is_vcs(dict(v)):
                 ps.update({k: v})
         return ps
 

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -185,7 +185,7 @@ def convert_deps_from_pip(dep):
             dependency[req.name].update({'editable': True})
 
     # VCS Installs.
-    if req.vcs:
+    elif req.vcs:
         if req.name is None:
             raise ValueError('pipenv requires an #egg fragment for version controlled '
                              'dependencies. Please install remote dependency '
@@ -269,7 +269,13 @@ def convert_deps_to_pip(deps, r=True):
 
         # Support for files.
         if 'file' in deps[dep]:
-            dep = deps[dep]['file']
+            extra = deps[dep]['file']
+            if 'editable' in deps[dep]:
+                # Support for --egg.
+                dep = '-e '
+            else:
+                dep = ''
+
 
         if vcs:
             extra = '{0}+{1}'.format(vcs, deps[dep][vcs])
@@ -347,7 +353,7 @@ def is_file(package):
     """Determine if a package name is for a File dependency."""
     # Check against pipfile TOML format
     if isinstance(package, dict):
-        return 'file' in package
+        return any(key for key in package.keys() if key == 'file')
 
     # Coimpare to string formats
     if os.path.exists(package):


### PR DESCRIPTION
* This now resolves relative paths correctly upon locking (not 100% sure if the hashing behavior is what we want, since the hash of the relative path will never match the hash of the absolute path -- maybe we should always hash teh absolute path even if we store the relative path?)
* For some ungodly reason this now also puts VCS urls and refs in the lockfile however.  I have no clue why.  