### PR TITLE
Test for posix compliance by checking posix compliance

### DIFF
--- a/pipenv/vendor/pexpect/popen_spawn.py
+++ b/pipenv/vendor/pexpect/popen_spawn.py
@@ -40,7 +40,7 @@ class PopenSpawn(SpawnBase):
             kwargs['creationflags'] = subprocess.CREATE_NEW_PROCESS_GROUP
 
         if not isinstance(cmd, (list, tuple)):
-            cmd = shlex.split(cmd, posix=sys.platform != 'win32')
+            cmd = shlex.split(cmd, posix=(os.name == 'posix'))
 
         self.proc = subprocess.Popen(cmd, **kwargs)
         self.closed = False


### PR DESCRIPTION
* Instead of testing for platform, which is not always accurate, it's better to test posix compliance by just checking whether we are posix compliant