### PR TITLE
fix: bold used in puts instead of crayon

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -1386,15 +1386,17 @@ def uninstall(
         if 'dev-packages' in project.parsed_pipfile:
             puts(
                 crayons.white(u'Un-installing {0}…'.format(
-                    crayons.red('[dev-packages]'))
-                ), bold=True
+                    crayons.red('[dev-packages]')), bold=True
+                )
             )
             package_names = project.parsed_pipfile['dev-packages']
             pipfile_remove = False
         else:
-            puts(crayons.white('No {0} to uninstall.'.format(
-                crayons.red('[dev-packages]'))), bold=True
-            ),
+            puts(
+                crayons.white('No {0} to uninstall.'.format(
+                    crayons.red('[dev-packages]')), bold=True
+                )
+            )
             sys.exit(0)
 
     if package_name is False and not dev:


### PR DESCRIPTION
bold was being used in puts instead of in crayon, breaking the code.

reproduce doing: `pipenv uninstall -d requests`