### PR TITLE
fix: uninstall dev expecting tuple, not dict

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -1390,6 +1390,7 @@ def uninstall(
                 )
             )
             package_names = project.parsed_pipfile['dev-packages']
+            package_names = package_names.keys()
             pipfile_remove = False
         else:
             puts(


### PR DESCRIPTION
Trying to do:
`pipenv uninstall -d nose`
raises a `KeyError` exception.

This fix the issue.