### PR TITLE
fix: uninstall dev now removes package from Pipfile

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -1472,7 +1472,6 @@ def uninstall(
             )
             package_names = project.parsed_pipfile['dev-packages']
             package_names = package_names.keys()
-            pipfile_remove = False
         else:
             puts(
                 crayons.white('No {0} to uninstall.'.format(

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -167,6 +167,35 @@ class TestPipenv():
         os.chdir('..')
         delegator.run('rm -fr test_pipenv_uninstall')
 
+    def test_pipenv_uninstall_dev(self):
+        delegator.run('mkdir test_pipenv_uninstall_dev')
+        os.chdir('test_pipenv_uninstall_dev')
+
+        # Build the environment.
+        os.environ['PIPENV_VENV_IN_PROJECT'] = '1'
+        assert delegator.run('touch Pipfile').return_code == 0
+        assert delegator.run('pipenv --python python').return_code == 0
+
+        # Add entries to Pipfile.
+        assert delegator.run('pipenv install pytest --dev').return_code == 0
+
+        pipfile_output = delegator.run('cat Pipfile').out
+        pipfile_list = pipfile_output.split('\n')
+
+        assert '[dev-packages]' in pipfile_list
+        assert 'pytest = "*"' in pipfile_list
+
+        # Uninstall from dev-packages, removing TOML section.
+        assert delegator.run('pipenv uninstall -d pytest').return_code == 0
+
+        pipfile_output = delegator.run('cat Pipfile').out
+        pipfile_list = pipfile_output.split('\n')
+
+        assert 'pytest = "*"' not in pipfile_list
+
+        os.chdir('..')
+        delegator.run('rm -fr test_pipenv_uninstall_dev')
+
     def test_pipenv_run(self):
         working_dir = 'test_pipenv_run'
         delegator.run('mkdir {0}'.format(working_dir))


### PR DESCRIPTION
Doing `pipenv uninstall -d <package>` does not remove the file from the
Pipfile. There was a flag preventing from doing so in `cli.uninstall`

Includes test

Closes #575

Note:
`test_cli_usage` is not passing for me because running `pipenv install regex` does not return `code == 0`