### PR TITLE
Bugfix: The newly added function `puts` should accept invokers' `err`…

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -112,7 +112,7 @@ def puts(s, err=False):
         if isinstance(s, unicode):
             s = s.encode('utf-8')
 
-    return click.echo(s, err=False)
+    return click.echo(s, err=err)
 
 
 # Disable warnings for Python 2.6.


### PR DESCRIPTION
Hi Reitz, I think the newly added function `puts` in `cli.py` should accept invoker's `err` value.