### PR TITLE
Improve pyenv detection

### DIFF
--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -51,4 +51,4 @@ PIPENV_TIMEOUT = int(os.environ.get('PIPENV_TIMEOUT', 120))
 
 PIPENV_INSTALL_TIMEOUT = 60 * 15
 
-PYENV_INSTALLED = os.environ.get('PYENV_ROOT')
+PYENV_INSTALLED = bool(os.environ.get('PYENV_SHELL'))


### PR DESCRIPTION
On my system, pipenv fails to detect the presence of pyenv, so it doesn't offer to download and install missing Python versions.

 I think `PYENV_ROOT` will only be set if the user explicitly sets it. It seems better to use `PYENV_SHELL` here. That one is set by `pyenv init`.

Also, I think it's a bit cleaner to use a `bool`  for the `PYENV_INSTALLED` variable.
