### PR TITLE
POC for plugin support (I don't expect it to be accepted, sending only as RFC)

### DIFF
--- a/examples/plugin/pipenv_hello.py
+++ b/examples/plugin/pipenv_hello.py
@@ -1,0 +1,7 @@
+import click
+
+
+@click.command()
+def main():
+    """The Hello Plugin"""
+    click.echo("Hello from pipenv plugin")

--- a/examples/plugin/setup.py
+++ b/examples/plugin/setup.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from setuptools import setup, find_packages
+
+
+setup(
+    name='pipenv_hello',
+    license='MIT',
+    version='1.0.0',
+    description='Example plugin to pipenv',
+    author='Bruno Rocha',
+    author_email='rochacbruno@gmail.com',
+    url='https://github.com/rochacbruno/pipenv_hello',
+    packages=find_packages(),
+    install_requires=['pipenv'],
+    entry_points={
+        'pipenv.extension': [
+            'hello = pipenv_hello:main',
+        ],
+    },
+    classifiers=[
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy'
+    ],
+)

--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -42,6 +42,7 @@ from .environments import (
     PIPENV_SKIP_VALIDATION, PIPENV_HIDE_EMOJIS, PIPENV_INSTALL_TIMEOUT,
     PYENV_INSTALLED, PIPENV_YES, PIPENV_DONT_LOAD_ENV
 )
+from .plugin_manager import PluginManager
 
 # Backport required for earlier versions of Python.
 if sys.version_info < (3, 3):
@@ -1516,9 +1517,6 @@ def do_py(system=False):
     click.echo(which('python', allow_global=system))
 
 
-
-
-
 @click.command(help="Installs provided packages and adds them to Pipfile, or (if none is given), installs all packages.", context_settings=dict(
     ignore_unknown_options=True,
     allow_extra_args=True
@@ -2010,7 +2008,6 @@ def check(three=None, python=False):
             sys.exit(1)
 
 
-
 @click.command(help=u"Displays currently–installed dependency graph information.")
 @click.option('--bare', is_flag=True, default=False, help="Minimal output.")
 @click.option('--json', is_flag=True, default=False, help="Output JSON.")
@@ -2148,7 +2145,6 @@ def update(dev=False, three=None, python=None, dry_run=False, bare=False, dont_u
     )
 
 
-
 # Install click commands.
 cli.add_command(graph)
 cli.add_command(install)
@@ -2159,6 +2155,7 @@ cli.add_command(check)
 cli.add_command(shell)
 cli.add_command(run)
 
+PluginManager(cli=cli)
 
 if __name__ == '__main__':
     cli()

--- a/pipenv/plugin_manager.py
+++ b/pipenv/plugin_manager.py
@@ -1,0 +1,109 @@
+import click
+import pkg_resources
+
+
+class PluginManager(object):  # pylint: disable=too-few-public-methods
+    """Find and manage plugins."""
+
+    def __init__(self, cli=None, namespace='pipenv.extension',
+                 verify_requirements=False):
+        """Initialize the manager.
+        :param str namespace:
+            Namespace of the plugins to manage, e.g., 'pipenv.extension'.
+        :param bool verify_requirements:
+            Whether or not to make setuptools verify that the requirements for
+            the plugin are satisfied.
+        """
+        self.namespace = namespace
+        self.verify_requirements = verify_requirements
+        self.plugins = {}
+        self.names = []
+        self.cli = cli
+        self._load_entrypoint_plugins()
+        # TODO: Use pluggy or blinker to register hooks?
+
+    def _load_entrypoint_plugins(self):
+        for entry_point in pkg_resources.iter_entry_points(self.namespace):
+            self._load_plugin_from_entrypoint(entry_point)
+
+    def _load_plugin_from_entrypoint(self, entry_point):
+        """Load a plugin from a setuptools EntryPoint.
+        :param EntryPoint entry_point:
+            EntryPoint to load plugin from.
+        """
+        name = entry_point.name
+        self.plugins[name] = Plugin(name, entry_point)
+        self.names.append(name)
+        if self.cli is not None:
+            self.cli.add_command(self.plugins[name].plugin, name=name)
+
+
+class Plugin(object):
+    """Wrap an EntryPoint from setuptools and other logic."""
+
+    def __init__(self, name, entry_point, verify_requirements=False):
+            """Initialize our Plugin.
+            :param str name:
+                Name of the entry-point as it was registered with setuptools.
+            :param entry_point:
+                EntryPoint returned by setuptools.
+            :type entry_point:
+                setuptools.EntryPoint
+            """
+            self.name = name
+            self.entry_point = entry_point
+            self._plugin = None
+            self._plugin_name = None
+            self._verify_requirements = verify_requirements
+
+    def __repr__(self):
+        """Provide an easy to read description of the current plugin."""
+        return 'Plugin(name="{0}", entry_point="{1}")'.format(
+            self.name, self.entry_point
+        )
+
+    @property
+    def plugin(self):
+        """Load and return the plugin associated with the entry-point.
+        This property implicitly loads the plugin and then caches it.
+        """
+        self.load_plugin()
+        return self._plugin
+
+    def execute(self, *args, **kwargs):
+        r"""Call the plugin with \*args and \*\*kwargs."""
+        return self.plugin(*args, **kwargs)  # pylint: disable=not-callable
+
+    def _load(self):
+        # Avoid relying on hasattr() here.
+        resolve = getattr(self.entry_point, 'resolve', None)
+        require = getattr(self.entry_point, 'require', None)
+        if resolve and require:
+            if self._verify_requirements:
+                require()
+            self._plugin = resolve()
+        else:
+            self._plugin = self.entry_point.load(
+                require=self._verify_requirements
+            )
+        if not callable(self._plugin):
+            msg = ('Plugin %r is not a callable'
+                   ' version' % self._plugin)
+            raise TypeError(msg)
+
+    def load_plugin(self):
+        """Retrieve the plugin for this entry-point.
+        This loads the plugin, stores it on the instance and then returns it.
+        It does not reload it after the first time, it merely returns the
+        cached plugin.
+        :returns:
+            Nothing
+        """
+        if self._plugin is None:
+            try:
+                self._load()
+            except Exception as e:
+                click.echo(
+                    'Cannot load the plugin %r with error %s' % (self, str(e))
+                )
+                # could use contextlib.supress here if only py3

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(
     packages=find_packages(exclude=['tests', 'tests_windows']),
     entry_points={
         'console_scripts': ['pipenv=pipenv:cli'],
+        'pipenv.extension': []
     },
     install_requires=required,
     include_package_data=True,


### PR DESCRIPTION
## Just a `POC` for plugin extensions

> I don't expect it to be accepted, sending only as a Request For Comments

### How it works?

1. Create a new plugin for example `pipenv_hello.py`:

```py
import click
@click.command()
def main():
    """The Hello Plugin"""
    click.echo("Hello from pipenv plugin")
```

2. Distribute it under `pipenv.extension` namespace

```py
# -*- coding: utf-8 -*-
from setuptools import setup, find_packages


setup(
    name='pipenv_hello',
    version='1.0.0',
    description='Example plugin to pipenv',
    packages=find_packages(),
    install_requires=['pipenv'],
    entry_points={
        'pipenv.extension': [
            'hello = pipenv_hello:main',
        ],
    }
)
```

3. Once in PyPI plugin can be installed

```bash
$ pipenv install pipenv_hello
```
or `pip install pipenv_hello`

4.  If the plugin provides new commands It will now be vailable

```bash
$ pipenv --help
...
Commands:
  ...
  hello      The Hello Plugin
  ...
```

5. Use it

```bash
$ pipenv hello
Hello from pipenv plugin
```
6. If the plugin only register `hooks` you will see it when running `pipenv listhooks` (not implemented yet)

## What is a plugin?
- Can register new `click.command` or `click.group` as subcommands to `pipenv` main command line group
- Can (or not) register `hooks`/`signals`
- has access to current project artifacts `Pipfile, virtualenv etc..`

## Ideas not implemented yet?
- Register hooks (or signals) that would be useful for example to intercept 'pre' and 'post' install operations and also 'pre' and 'post' for any command like 'lock', 'install'.
*not sure yet if hook system as in `pluggy` or signals as in `blinker` that would be useful to intercept `pre` and `post` operations.

## Stable?
- NO! just a POC/**RFC** needs tests, not intended to be merged.

## Use cases?

One can create a new plugin called `pipenv_publish` or `pipenv_setup` when installed with `pip install pipenv_<plugin_name>` it will add more subcommands to `pipenv` i.e: `setup` and `publish`

- `pipenv setup` would use pipenv helper functions to parse `Pipfile` requirements and a section called `package` to generate a `setup.py` file.

- `pipenv publish` would check the existence of that file and then use `twine` to upload to `PyPI`

- Other plugin ideas would be `pipenv bumpversion` (to use with publish) `pipenv build` `pipenv test` etc....

As you can see my motivation is primarily to use the same `pipenv` environment to distribute my packages (as I am developing frameworks that makes sense)

However, this open opportunity for other plugins to be developed.

For example, all the `poet` and `hatch` functionalities can be migrated to `pipenv` via plugins.

https://github.com/sdispater/poet
https://github.com/ofek/hatch

