### PR TITLE
Remove extra touch of the Pipfile during run

### DIFF
--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -311,11 +311,14 @@ class Project(object):
 
     @property
     def pipfile_is_empty(self):
-        self.touch_pipfile()
+        if not self.pipfile_exists:
+            return True
 
         with open('Pipfile', 'r') as f:
             if not f.read():
                 return True
+
+        return False
 
     def create_pipfile(self, python=None):
         """Creates the Pipfile, filled with juicy defaults."""


### PR DESCRIPTION
Fixes #546

`touch_pipfile` is already called from `ensure_project` if needed.