### PR TITLE
simplify code in find_a_system_python

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -365,15 +365,12 @@ def find_a_system_python(python):
             if os.name == 'nt':
                 possibility = '{0}.exe'.format(possibility)
 
-            versions = []
             pythons = system_which(possibility, mult=True)
 
             for p in pythons:
-                versions.append(python_version(p))
-
-            for i, version in enumerate(versions):
+                version = python_version(p)
                 if (version or '').startswith(python):
-                    return pythons[i]
+                    return p
 
 
 def ensure_python(three=None, python=None):


### PR DESCRIPTION
Thanks for recommending [`PIPENV_DEFAULT_PYTHON_VERSION`](https://twitter.com/kennethreitz/status/912068103588245507). I was taking a look at the source, to see how it worked and this function looked ripe for simplifying. 

(Not sure if micro contributions like this are always helpful, so feel free to feedback on that :smile: )

Also I see it ignores anything more detailed that x.y.
