### PR TITLE
Windows tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ python:
   - "3.5"
   - "3.6"
   - "pypy"
-  - "pypy3"
-  # TODO: pkg_config issues
+  - "3.7-dev"
+  # - "pypy3" # TODO: pkg_config issues
   # - "3.7-dev"
 
 # command to install dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "pypy"
+  - "pypy3"
+  # TODO: pkg_config issues
   # - "3.7-dev"
-  # - "pypy"
-  # - "pypy3" # TODO: pkg_config issues
 
 # command to install dependencies
 install:

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,4 @@ sphinx = "<=1.5.5"
 "-e ." = "*"
 twine = "*"
 "sphinx-click" = "*"
-"pytest-xdist" = {version = "*", os_name = "=='posix'"}
-
-
-
+"pytest-xdist" = *

--- a/Pipfile
+++ b/Pipfile
@@ -7,4 +7,4 @@ sphinx = "<=1.5.5"
 "-e ." = "*"
 twine = "*"
 "sphinx-click" = "*"
-"pytest-xdist" = *
+"pytest-xdist" = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -10,5 +10,4 @@ twine = "*"
 "pytest-xdist" = {version = "*", os_name = "=='posix'"}
 
 
-[requires]
-python_version = "3.6"
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,4 +52,4 @@ install:
   - "pipenv install --system --dev --skip-lock"
 
 test_script:
-  - "pytest tests/test_pipenv.py tests/test_project.py tests/test_utils.py"
+  - "pipenv run pytest -n 8 tests/test_pipenv.py tests/test_project.py tests/test_utils.py"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,9 +15,19 @@ environment:
       PYTHON_ARCH: "64"
       TOXENV: "py27"
 
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: "32"
+      TOXENV: "py27"
+
     - PYTHON: "C:\\Python34-x64"
       PYTHON_VERSION: "3.4.x"
       PYTHON_ARCH: "64"
+      TOXENV: "py34"
+
+    - PYTHON: "C:\\Python34"
+      PYTHON_VERSION: "3.4.x"
+      PYTHON_ARCH: "32"
       TOXENV: "py34"
 
     - PYTHON: "C:\\Python35-x64"
@@ -25,9 +35,19 @@ environment:
       PYTHON_ARCH: "64"
       TOXENV: "py35"
 
+    - PYTHON: "C:\\Python35"
+      PYTHON_VERSION: "3.5.x"
+      PYTHON_ARCH: "32"
+      TOXENV: "py35"
+
     - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
+      TOXENV: "py36"
+
+    - PYTHON: "C:\\Python36"
+      PYTHON_VERSION: "3.6.x"
+      PYTHON_ARCH: "32"
       TOXENV: "py36"
 
 install:


### PR DESCRIPTION
This fixes issue #686.  The windows tests were failing mainly due to the python_requires in the pipfile saying that 3.6 was required.  This made the tests only pass on windows when using 3.6.  I don't know if this is intended and we need to redirect it, or if removing it from the pipfile is a fine solution.  I also added in tests for pypy, python3.7-dev for travis and they seem to work fine (we can disable them if we need speed, the pypy test is slow at 9-10 minutes).  I also added 32-bit versions of pythons to the test matrix in appveyor.yml.