### PR TITLE
Fix typo in sequential flag help

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -1626,7 +1626,7 @@ def do_py(system=False):
 @click.option('--code', '-c', nargs=1, default=False, help="Import from codebase.")
 @click.option('--verbose', is_flag=True, default=False, help="Verbose mode.")
 @click.option('--ignore-pipfile', is_flag=True, default=False, help="Ignore Pipfile when installing, using the Pipfile.lock.")
-@click.option('--sequential', is_flag=True, default=False, help="Install dependencies one-at-a-time, isntead of concurrently.")
+@click.option('--sequential', is_flag=True, default=False, help="Install dependencies one-at-a-time, instead of concurrently.")
 @click.option('--skip-lock', is_flag=True, default=False, help=u"Ignore locking mechanisms when installing—use the Pipfile, instead.")
 @click.option('--pre', is_flag=True, default=False, help=u"Allow pre–releases.")
 def install(


### PR DESCRIPTION
Little typo snuck in https://github.com/kennethreitz/pipenv/commit/f08fb1f2713a97540bb5036d312acc5ecd1ddb58#diff-e1e68886e05fef92bb74ed1699e5179eR1534.

Thanks for all the work on this project.