### PR TITLE
Fix reST syntax errors

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -63,7 +63,7 @@ Magic. Pure, unadulterated magic.
 
 
 ☤ Deploying System Dependencies
-------------------------------
+-------------------------------
 
 You can tell Pipenv to install things into its parent system with the ``--system`` flag::
 

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -1,4 +1,4 @@
-.. _advanced:
+.. _basic:
 
 Basic Usage of Pipenv
 =====================
@@ -122,6 +122,7 @@ Example Pipfile.lock
 
 
 .. _initialization:
+
 ☤ Importing from requirements.txt
 ---------------------------------
 
@@ -250,7 +251,7 @@ Pipenv automatically honors both the ``python_full_version`` and ``python_versio
 The three primary commands you'll use in managing your pipenv environment are
 ``$ pipenv install``, ``$ pipenv uninstall``, and ``$ pipenv lock``.
 
-.. _pipenv_install
+.. _pipenv_install:
 
 $ pipenv install
 ////////////////
@@ -283,7 +284,7 @@ The user can provide these additional parameters:
     - ``--ignore-pipfile`` — Ignore the ``Pipfile`` and install from the ``Pipfile.lock``.
     - ``--skip-lock`` — Ignore the ``Pipfile.lock`` and install from the ``Pipfile``. In addition, do not write out a ``Pipfile.lock`` reflecting changes to the ``Pipfile``.
 
-.. _pipenv_uninstall
+.. _pipenv_uninstall:
 
 $ pipenv uninstall
 //////////////////
@@ -295,7 +296,7 @@ as well as one additonal, ``--all``.
       but leave the Pipfile untouched.
 
 
-.. _pipenv_lock
+.. _pipenv_lock:
 
 $ pipenv lock
 /////////////


### PR DESCRIPTION
This PR resolve problems casing following error messages.

```
WARNING: /Users/tomohiko/MyRepos/Python/pipenv/docs/advanced.rst:66: (WARNING/2) Title underline too short.

☤ Deploying System Dependencies
------------------------------
WARNING: /Users/tomohiko/MyRepos/Python/pipenv/docs/advanced.rst:66: (WARNING/2) Title underline too short.

☤ Deploying System Dependencies
------------------------------
/Users/tomohiko/MyRepos/Python/pipenv/docs/basics.rst:125: WARNING: Explicit markup ends without a blank line; unexpected unindent.
/Users/tomohiko/MyRepos/Python/pipenv/docs/basics.rst:253: WARNING: malformed hyperlink target.
/Users/tomohiko/MyRepos/Python/pipenv/docs/basics.rst:286: WARNING: malformed hyperlink target.
/Users/tomohiko/MyRepos/Python/pipenv/docs/basics.rst:298: WARNING: malformed hyperlink target.
/Users/tomohiko/MyRepos/Python/pipenv/docs/basics.rst:4: WARNING: duplicate label advanced, other instance in /Users/tomohiko/MyRepos/Python/pipenv/docs/advanced.rst
```