### PR TITLE
Add shell integration section to documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,6 +103,13 @@ Magic shell completions are now enabled! There is also a `fish plugin <https://g
 
 Fish is the best shell. You should use it.
 
+Shell Integration
+/////////////////
+
+If you are using a virtualenv aware prompt (as the excellent bobthefish) you should disable the default and ugly activate.fish behaviour. Put this in your ``~/.config/fish/config.fish``::
+
+    set -x VIRTUAL_ENV_DISABLE_PROMPT 1
+
 ☤ Usage
 -------
 

--- a/README.rst
+++ b/README.rst
@@ -106,7 +106,7 @@ Fish is the best shell. You should use it.
 Shell Integration
 /////////////////
 
-If you are using a virtualenv aware prompt (as the excellent bobthefish) you should disable the default and ugly activate.fish behaviour. Put this in your ``~/.config/fish/config.fish``::
+If you are using a virtualenv aware prompt (as the excellent `bobthefish <https://github.com/oh-my-fish/theme-bobthefish>`_) you should disable the default and ugly activate.fish behaviour. Put this in your ``~/.config/fish/config.fish``::
 
     set -x VIRTUAL_ENV_DISABLE_PROMPT 1
 

--- a/README.rst
+++ b/README.rst
@@ -106,7 +106,7 @@ Fish is the best shell. You should use it.
 Shell Integration
 /////////////////
 
-If you are using a virtualenv aware prompt (as the excellent `bobthefish <https://github.com/oh-my-fish/theme-bobthefish>`_) you should disable the default and ugly activate.fish behaviour. Put this in your ``~/.config/fish/config.fish``::
+If you are using a virtualenv aware prompt (as the excellent `bobthefish <https://github.com/oh-my-fish/theme-bobthefish>`_) you should disable the default and ugly ``activate.fish`` behaviour. Put this in your ``~/.config/fish/config.fish``::
 
     set -x VIRTUAL_ENV_DISABLE_PROMPT 1
 


### PR DESCRIPTION
The default activate.fish behaviour will set an ugly prompt, especially when using a virtualenv aware prompt like bobthefish.
This behaviour can be changed by manually setting an environmental variable.
A clean, elegant prompt is a must for such a refined piece of software as pipenv.

I propose a shell integration section to provide this info. In the future it could grow with additional tips (relevant to other shells, even if I do not see why to use them instead of beautiful fish).