### PR TITLE
Fix unicode decode error on windows

### DIFF
--- a/pipenv/patched/pip/compat/__init__.py
+++ b/pipenv/patched/pip/compat/__init__.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division
 
 import os
 import sys
+import locale
 
 from pip._vendor.six import text_type
 
@@ -72,6 +73,10 @@ if sys.version_info >= (3,):
         try:
             return s.decode(sys.__stdout__.encoding)
         except UnicodeDecodeError:
+            if sys.__stdout__.encoding == 'utf-8':
+                encoding = locale.getdefaultlocale()[1]
+                if encoding is not None and encoding.lower() != 'utf-8':
+                    return s.decode(encoding)
             return s.decode('utf_8')
 
     def native_str(s, replace=False):

--- a/pipenv/vendor/delegator.py
+++ b/pipenv/vendor/delegator.py
@@ -2,6 +2,8 @@ import os
 import subprocess
 import shlex
 import signal
+import sys
+import locale
 
 from pexpect.popen_spawn import PopenSpawn
 
@@ -46,9 +48,14 @@ class Command(object):
 
     @property
     def _default_pexpect_kwargs(self):
+        encoding = 'utf-8'
+        if sys.platform == 'win32':
+            default_encoding = locale.getdefaultlocale()[1]
+            if default_encoding is not None:
+                encoding = default_encoding
         return {
             'env': os.environ.copy(),
-            'encoding': 'utf-8',
+            'encoding': encoding,
             'timeout': self.timeout
         }
 


### PR DESCRIPTION
I use the `pipenv install` command on windows,, but there was a UnicodeDecodeError:

``` plain
PS E:\repos\GitHub\myapp> pipenv install
Creating a virtualenv for this project…
Traceback (most recent call last):
  File "D:\Program Files\Python36\Scripts\pipenv-script.py", line 11, in <module>
    load_entry_point('pipenv==8.2.6', 'console_scripts', 'pipenv')()
  File "d:\program files\python36\lib\site-packages\pipenv\vendor\click\core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "d:\program files\python36\lib\site-packages\pipenv\vendor\click\core.py", line 697, in main
    rv = self.invoke(ctx)
  File "d:\program files\python36\lib\site-packages\pipenv\vendor\click\core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "d:\program files\python36\lib\site-packages\pipenv\vendor\click\core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "d:\program files\python36\lib\site-packages\pipenv\vendor\click\core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "d:\program files\python36\lib\site-packages\pipenv\cli.py", line 1736, in install
    ensure_project(three=three, python=python, system=system, warn=True, deploy=deploy)
  File "d:\program files\python36\lib\site-packages\pipenv\cli.py", line 588, in ensure_project
    ensure_virtualenv(three=three, python=python, site_packages=site_packages)
  File "d:\program files\python36\lib\site-packages\pipenv\cli.py", line 559, in ensure_virtualenv
    do_create_virtualenv(python=python, site_packages=site_packages)
  File "d:\program files\python36\lib\site-packages\pipenv\cli.py", line 929, in do_create_virtualenv
    click.echo(crayons.blue(c.out), err=True)
  File "d:\program files\python36\lib\site-packages\pipenv\vendor\delegator.py", line 92, in out
    self.__out = self._pexpect_out
  File "d:\program files\python36\lib\site-packages\pipenv\vendor\delegator.py", line 80, in _pexpect_out
    result += self.subprocess.read()
  File "d:\program files\python36\lib\site-packages\pipenv\vendor\pexpect\spawnbase.py", line 413, in read
    self.expect(self.delimiter)
  File "d:\program files\python36\lib\site-packages\pipenv\vendor\pexpect\spawnbase.py", line 321, in expect
    timeout, searchwindowsize, async)
  File "d:\program files\python36\lib\site-packages\pipenv\vendor\pexpect\spawnbase.py", line 345, in expect_list
    return exp.expect_loop(timeout)
  File "d:\program files\python36\lib\site-packages\pipenv\vendor\pexpect\expect.py", line 99, in expect_loop
    incoming = spawn.read_nonblocking(spawn.maxread, timeout)
  File "d:\program files\python36\lib\site-packages\pipenv\vendor\pexpect\popen_spawn.py", line 86, in read_nonblocking
    buf += self._decoder.decode(incoming, final=False)
  File "d:\program files\python36\lib\codecs.py", line 321, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc1 in position 34: invalid start byte
```

I guess this error is because my windows username non-ansi characters caused. After some debugging I found that the `encoding` parameter value is `"utf-8"` at [pipenv/vendor/delegator.py:51](https://github.com/kennethreitz/pipenv/blob/master/pipenv/vendor/delegator.py#L51), So I added the judgment, if the current system is windows, then use the default encoding.

After modifying the code, I run the `pipenv install` command again, the previous error is gone, but there is a new error:

``` plain

PS E:\repos\GitHub\myapp> pipenv install
Creating a virtualenv for this project…
Using base prefix 'd:\\program files\\python36'
New python executable in C:\Users\刘超\.virtualenvs\myapp-rBAgOmmu\Scripts\python.exe
Installing setuptools, pip, wheel...done.

Virtualenv location: C:\Users\刘超\.virtualenvs\myapp-rBAgOmmu
Pipfile.lock not found, creating…
Locking [dev-packages] dependencies…
Locking [packages] dependencies…
Traceback (most recent call last):
  File "d:\program files\python36\lib\site-packages\pipenv\patched\pip\compat\__init__.py", line 73, in console_to_str
    return s.decode(sys.__stdout__.encoding)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa1 in position 39: invalid start byte

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "D:\Program Files\Python36\Scripts\pipenv-script.py", line 11, in <module>
    load_entry_point('pipenv==8.2.6', 'console_scripts', 'pipenv')()
  File "d:\program files\python36\lib\site-packages\pipenv\vendor\click\core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "d:\program files\python36\lib\site-packages\pipenv\vendor\click\core.py", line 697, in main
    rv = self.invoke(ctx)
  File "d:\program files\python36\lib\site-packages\pipenv\vendor\click\core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "d:\program files\python36\lib\site-packages\pipenv\vendor\click\core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "d:\program files\python36\lib\site-packages\pipenv\vendor\click\core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "d:\program files\python36\lib\site-packages\pipenv\cli.py", line 1785, in install
    do_init(dev=dev, allow_global=system, ignore_pipfile=ignore_pipfile, system=system, skip_lock=skip_lock, verbose=verbose, concurrent=concurrent, deploy=deploy)
  File "d:\program files\python36\lib\site-packages\pipenv\cli.py", line 1293, in do_init
    do_lock(system=system)
  File "d:\program files\python36\lib\site-packages\pipenv\cli.py", line 1083, in do_lock
    pre=pre
  File "d:\program files\python36\lib\site-packages\pipenv\utils.py", line 421, in resolve_deps
    resolved_tree.update(resolver.resolve(max_rounds=PIPENV_MAX_ROUNDS))
  File "d:\program files\python36\lib\site-packages\pipenv\patched\piptools\resolver.py", line 101, in resolve
    has_changed, best_matches = self._resolve_one_round()
  File "d:\program files\python36\lib\site-packages\pipenv\patched\piptools\resolver.py", line 199, in _resolve_one_round
    for dep in self._iter_dependencies(best_match):
  File "d:\program files\python36\lib\site-packages\pipenv\patched\piptools\resolver.py", line 293, in _iter_dependencies
    dependencies = self.repository.get_dependencies(ireq)
  File "d:\program files\python36\lib\site-packages\pipenv\patched\piptools\repositories\pypi.py", line 171, in get_dependencies
    result = reqset._prepare_file(self.finder, ireq)
  File "d:\program files\python36\lib\site-packages\pipenv\patched\pip\req\req_set.py", line 639, in _prepare_file
    abstract_dist.prep_for_dist()
  File "d:\program files\python36\lib\site-packages\pipenv\patched\pip\req\req_set.py", line 134, in prep_for_dist
    self.req_to_install.run_egg_info()
  File "d:\program files\python36\lib\site-packages\pipenv\patched\pip\req\req_install.py", line 438, in run_egg_info
    command_desc='python setup.py egg_info')
  File "d:\program files\python36\lib\site-packages\pipenv\patched\pip\utils\__init__.py", line 676, in call_subprocess
    line = console_to_str(proc.stdout.readline())
  File "d:\program files\python36\lib\site-packages\pipenv\patched\pip\compat\__init__.py", line 75, in console_to_str
    return s.decode('utf_8')
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa1 in position 39: invalid start byte
```

The actual encoding of the string of `proc.stdout.readline()` return is not `“utf-8”`, so I added the judgment into [pipenv/patched/pip/compat/\_\_init\_\_.py:74](https://github.com/kennethreitz/pipenv/blob/master/pipenv/patched/pip/compat/__init__.py#L74), if `sys.__stdout__.encoding` value is `"utf-8"`, but default encoding is not utf-8, then try use default encoding to decode string.

I run the `pipenv install` command again, no error, everything is fine.

``` plain
PS E:\repos\GitHub\myapp> pipenv install
Pipfile.lock not found, creating…
Locking [dev-packages] dependencies…
Locking [packages] dependencies…
Updated Pipfile.lock (7a8d67)!
Installing dependencies from Pipfile.lock (7a8d67)…
  ================================ 39/39 - 00:00:39
To activate this project's virtualenv, run the following:
 $ pipenv shell
```