### PR TITLE
Fix check --unused

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.rst LICENSE NOTICES HISTORY.txt pipenv/patched/safety.zip
 include pipenv/vendor/pipreqs/stdlib
+include pipenv/vendor/pipreqs/mapping
 include pipenv/pipenv.1

--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -287,7 +287,8 @@ def import_from_code(path='.'):
         for r in pipreqs.get_all_imports(path):
             if r not in BAD_PACKAGES:
                 rs.append(r)
-        return [proper_case(r) for r in rs]
+        pkg_names = pipreqs.get_pkg_names(rs)
+        return [proper_case(r) for r in pkg_names]
     except Exception:
         return []
 
@@ -2186,7 +2187,7 @@ def check(three=None, python=False, unused=False, style=False, args=None):
 
     if unused:
         deps_required = [k for k in project.packages.keys()]
-        deps_needed = [k.lower() for k in import_from_code(unused)]
+        deps_needed = import_from_code(unused)
 
         for dep in deps_needed:
             try:


### PR DESCRIPTION
- Add missing `mapping` file from vendored `pipreqs` to dist
- Resolve non-stdlib package names using `mapping` file before checking PyPI
- Do not `lower` needed package names after resolving them with `pipreqs`