### PR TITLE
Bugfix/git ssh vcs url

### DIFF
--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -60,15 +60,16 @@ class Project(object):
             if hasattr(v, 'keys'):
                 # When a vcs url is gven without editable it only appears as a key
                 if is_vcs(v) or is_vcs(k):
+                    # Non-editable VCS entries can't be resolved by piptools
                     if 'editable' not in v:
                         continue
                     else:
                         ps.update({k: v})
                 else:
-                    if not is_file(v) and not is_file(k) and not is_vcs(v) and not is_vcs(k):
+                    if not is_file(v) and not is_file(k):
                         ps.update({k: v})
             else:
-                if not is_vcs(k) and not is_file(k):
+                if not is_vcs(k) and not is_file(k) and not is_vcs(v):
                     ps.update({k: v})
         return ps
 

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -495,8 +495,7 @@ def convert_deps_from_pip(dep):
 
     req = [r for r in requirements.parse(dep)][0]
     extras = {'extras': req.extras}
-    
-    
+
 
     # File installs.
     if (req.uri or (os.path.exists(req.path) if req.path else False) or

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -532,7 +532,7 @@ def convert_deps_from_pip(dep):
         # Set up this requirement as a proper VCS requirement if it was not
         if not req.vcs and req.path.startswith(VCS_LIST):
             req.vcs = [vcs for vcs in VCS_LIST if req.path.startswith(vcs)][0]
-            req.uri = '{0}'.format(req.path) #.replace(':', '/', 1).replace('@', '://', 1)
+            req.uri = '{0}'.format(req.path)
             req.path = None
 
         # Crop off the git+, etc part.


### PR DESCRIPTION
* Fix Requirement objects that use git+git@host:user/repo.git syntax
* Requirements are not natively being recognized as VCS requirements
* This converts them to VCS by moving req.path to req.uri and adding
* Adds req.vcs flag
* Remove some redundancies from project package filtering
* Fixes #788 (Maybe) -- see discussion in the issue