### PR TITLE
Reset the InstallRequirement.prepared attribute when yeilding dependencies

### DIFF
--- a/pipenv/patched/piptools/resolver.py
+++ b/pipenv/patched/piptools/resolver.py
@@ -276,9 +276,12 @@ class Resolver(object):
             return
         elif ireq.markers:
             for dependency in self.repository.get_dependencies(ireq):
+                dependency.prepared = False
                 yield dependency
+            return
         elif ireq.extras:
             for dependency in self.repository.get_dependencies(ireq):
+                dependency.prepared = False
                 yield dependency
             return
         elif not is_pinned_requirement(ireq):


### PR DESCRIPTION
Fixes #839
This well ensure the dependencies are well-fetched on the next iteration too.

I think this patched section could be removed, but I can't give a 100% guarantee right away, so I'll submit this fix for now and will leave the "full" resolving of markers later.