### PR TITLE
Ensure python version is installed before deleting existing virtual env

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -565,10 +565,14 @@ def ensure_virtualenv(three=None, python=None, site_packages=False):
 
     # If --three, --two, or --python were passed...
     elif (python) or (three is not None) or (site_packages is not False):
+       
+        USING_DEFAULT_PYTHON = False
+        
+        # Ensure python is installed before deleting existing virtual env
+        ensure_python(three=three, python=python)
+
         click.echo(crayons.red('Virtualenv already exists!'), err=True)
         click.echo(crayons.normal(u'Removing existing virtualenv…', bold=True), err=True)
-
-        USING_DEFAULT_PYTHON = False
 
         # Remove the virtualenv.
         cleanup_virtualenv(bare=True)


### PR DESCRIPTION
When specifying a python (`--three, --two or --python`) version, `pipenv` deletes the existing virtual env **before** checking if the specified version is installed.

With this change, pipenv can prevent mistyped versions, or even undesirable actions; suppose someone cannot download a new python version due to a limited network etc.