### PR TITLE
fix installing with compatible release specifier

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -1762,11 +1762,7 @@ def install(
         if package_names[0]:
             if not package_names[0].startswith('-e '):
                 if not is_file(package_names[0]):
-                    if not (
-                        ('==' in package_names[0]) or
-                        ('>=' in package_names[0]) or
-                        ('<=' in package_names[0])
-                    ):
+                    if not any(op in package_names[0] for op in '!=<>~'):
                         suggested_package = suggest_package(package_names[0])
                         if suggested_package:
                             if str(package_names[0].lower()) != str(suggested_package.lower()):

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -587,7 +587,7 @@ def convert_deps_from_pip(dep):
         specs = None
         # Comparison operators: e.g. Django>1.10
         if req.specs:
-            r = multi_split(dep, '!=<>')
+            r = multi_split(dep, '!=<>~')
             specs = dep[len(r[0]):]
             dependency[req.name] = specs
 


### PR DESCRIPTION
Fix #851.

Enabled adding a package specified with `~=` compatible release specifier.
Disabled "did u mean" suggestion for packages specified with `!=`, `>`, `<`, `~=`