### PR TITLE
Use consistant os check with os.name (import nt does not guaranty to be on windows)

### DIFF
--- a/pipenv/vendor/pathlib.py
+++ b/pipenv/vendor/pathlib.py
@@ -28,16 +28,15 @@ except NameError:
     basestring = str
 
 supports_symlinks = True
-try:
+if os.name == 'nt':
     import nt
-except ImportError:
-    nt = None
-else:
     if sys.getwindowsversion()[:2] >= (6, 0) and sys.version_info >= (3, 2):
         from nt import _getfinalpathname
     else:
         supports_symlinks = False
         _getfinalpathname = None
+else:
+    nt = None
 
 
 __all__ = [


### PR DESCRIPTION
A file, folder or package can produce a name conflict with nt on non windows systems.
Also https://github.com/python/cpython/blob/master/Lib/pathlib.py uses `os.name`.