### PR TITLE
 Fix pep508 logic assuming single-digit minor versions

### DIFF
--- a/pipenv/patched/pip/_vendor/packaging/markers.py
+++ b/pipenv/patched/pip/_vendor/packaging/markers.py
@@ -266,7 +266,7 @@ def default_environment():
         "platform_version": platform.version(),
         "python_full_version": platform.python_version(),
         "platform_python_implementation": platform.python_implementation(),
-        "python_version": platform.python_version()[:3],
+        "python_version": '.'.join(map(str, sys.version_info[:2])),
         "sys_platform": sys.platform,
     }
 

--- a/pipenv/pep508checker.py
+++ b/pipenv/pep508checker.py
@@ -33,7 +33,7 @@ lookup = {
     'platform_release': platform.release(),
     'platform_system': platform.system(),
     'platform_version': platform.version(),
-    'python_version': platform.python_version()[:3],
+    'python_version': '.'.join(map(str, sys.version_info[:2])),
     'python_full_version': platform.python_version(),
     'implementation_name': implementation_name,
     'implementation_version': implementation_version


### PR DESCRIPTION
If the python version were to reach `3.10.0`, the logic from pep508 would result in a `python_version` of `3.1` instead of `3.10`

