### PR TITLE
Shells with PIPENV_IGNORE_VIRTUALENVS on win

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -2038,7 +2038,8 @@ def do_shell(three=None, python=False, fancy=False, shell_args=None):
         import subprocess
         # Tell pew to use the project directory as its workon_home
         with temp_environ():
-            os.environ['WORKON_HOME'] = project.project_directory
+            if PIPENV_VENV_IN_PROJECT:
+                os.environ['WORKON_HOME'] = project.project_directory
             p = subprocess.Popen([cmd] + list(args), shell=True, universal_newlines=True)
             p.communicate()
             sys.exit(p.returncode)

--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -25,19 +25,17 @@ import pipdeptree
 import requirements
 import semver
 import flake8.main.cli
-import pew
 from pipreqs import pipreqs
 from blindspin import spinner
 from urllib3.exceptions import InsecureRequestWarning
 from pip.req.req_file import parse_requirements
 from click_didyoumean import DYMCommandCollection
-
 from .project import Project
 from .utils import (
     convert_deps_from_pip, convert_deps_to_pip, is_required_version,
     proper_case, pep423_name, split_vcs, resolve_deps, shellquote, is_vcs,
     python_version, suggest_package, find_windows_executable, is_file,
-    prepare_pip_source_args
+    prepare_pip_source_args, temp_environ
 )
 from .__version__ import __version__
 from . import pep508checker, progress
@@ -2039,7 +2037,7 @@ def do_shell(three=None, python=False, fancy=False, shell_args=None):
     except AttributeError:
         import subprocess
         # Tell pew to use the project directory as its workon_home
-        with pew.pew.temp_environ():
+        with temp_environ():
             os.environ['WORKON_HOME'] = project.project_directory
             p = subprocess.Popen([cmd] + list(args), shell=True, universal_newlines=True)
             p.communicate()

--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -2024,14 +2024,18 @@ def do_shell(three=None, python=False, fancy=False, shell_args=None):
     terminal_dimensions = get_terminal_size()
 
     try:
-        c = pexpect.spawn(
-            cmd,
-            args,
-            dimensions=(
-                terminal_dimensions.lines,
-                terminal_dimensions.columns
+        with temp_environ():
+            if PIPENV_VENV_IN_PROJECT:
+                os.environ['WORKON_HOME'] = project.project_directory
+
+            c = pexpect.spawn(
+                cmd,
+                args,
+                dimensions=(
+                    terminal_dimensions.lines,
+                    terminal_dimensions.columns
+                )
             )
-        )
 
     # Windows!
     except AttributeError:

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -22,6 +22,7 @@ try:
 except ImportError:
     from urlparse import urlparse
 
+from contextlib import contextmanager
 from piptools.resolver import Resolver
 from piptools.repositories.pypi import PyPIRepository
 from piptools.scripts.compile import get_pip_command
@@ -913,3 +914,16 @@ def find_requirements(max_depth=3):
                 if os.path.isfile(r):
                     return r
     raise RuntimeError('No requirements.txt found!')
+
+
+# Borrowed from pew to avoid importing pew which imports psutil
+# See https://github.com/berdario/pew/blob/master/pew/_utils.py#L82
+@contextmanager
+def temp_environ():
+    """Allow the ability to set os.environ temporarily"""
+    environ = dict(os.environ)
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(environ)

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -6,6 +6,7 @@ import json
 import pytest
 
 from pipenv.cli import activate_virtualenv
+from pipenv.utils import temp_environ
 from pipenv.vendor import toml
 from pipenv.vendor import delegator
 from pipenv.project import Project
@@ -271,33 +272,32 @@ class TestPipenv:
     @pytest.mark.run
     @pytest.mark.install
     def test_multiprocess_bug_and_install(self):
-        os.environ['PIPENV_MAX_SUBPROCESS'] = '2'
+        with temp_environ():
+            os.environ['PIPENV_MAX_SUBPROCESS'] = '2'
 
-        with PipenvInstance() as p:
-            with open(p.pipfile_path, 'w') as f:
-                contents = """
+            with PipenvInstance() as p:
+                with open(p.pipfile_path, 'w') as f:
+                    contents = """
 [packages]
 requests = "*"
 records = "*"
 tpfd = "*"
-                """.strip()
-                f.write(contents)
+                    """.strip()
+                    f.write(contents)
 
-            c = p.pipenv('install')
-            assert c.return_code == 0
+                c = p.pipenv('install')
+                assert c.return_code == 0
 
-            assert 'requests' in p.lockfile['default']
-            assert 'idna' in p.lockfile['default']
-            assert 'urllib3' in p.lockfile['default']
-            assert 'certifi' in p.lockfile['default']
-            assert 'records' in p.lockfile['default']
-            assert 'tpfd' in p.lockfile['default']
-            assert 'parse' in p.lockfile['default']
+                assert 'requests' in p.lockfile['default']
+                assert 'idna' in p.lockfile['default']
+                assert 'urllib3' in p.lockfile['default']
+                assert 'certifi' in p.lockfile['default']
+                assert 'records' in p.lockfile['default']
+                assert 'tpfd' in p.lockfile['default']
+                assert 'parse' in p.lockfile['default']
 
-            c = p.pipenv('run python -c "import requests; import idna; import certifi; import records; import tpfd; import parse;"')
-            assert c.return_code == 0
-
-            del os.environ['PIPENV_MAX_SUBPROCESS']
+                c = p.pipenv('run python -c "import requests; import idna; import certifi; import records; import tpfd; import parse;"')
+                assert c.return_code == 0
 
     @pytest.mark.sequential
     @pytest.mark.install
@@ -445,14 +445,13 @@ requests = {version = "*"}
     @pytest.mark.dotvenv
     def test_venv_in_project(self):
 
-        os.environ['PIPENV_VENV_IN_PROJECT'] = '1'
-        with PipenvInstance() as p:
-            c = p.pipenv('install requests')
-            assert c.return_code == 0
+        with temp_environ():
+            os.environ['PIPENV_VENV_IN_PROJECT'] = '1'
+            with PipenvInstance() as p:
+                c = p.pipenv('install requests')
+                assert c.return_code == 0
 
-            assert p.path in p.pipenv('--venv').out
-
-        del os.environ['PIPENV_VENV_IN_PROJECT']
+                assert p.path in p.pipenv('--venv').out
 
     @pytest.mark.run
     @pytest.mark.dotenv

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -6,7 +6,7 @@ import json
 import pytest
 
 from pipenv.cli import activate_virtualenv
-from pipenv.utils import temp_environ
+from pipenv.utils import temp_environ, get_windows_path
 from pipenv.vendor import toml
 from pipenv.vendor import delegator
 from pipenv.project import Project
@@ -452,6 +452,49 @@ requests = {version = "*"}
                 assert c.return_code == 0
 
                 assert p.path in p.pipenv('--venv').out
+
+    @pytest.mark.dotvenv
+    @pytest.mark.install
+    @pytest.mark.complex
+    @pytest.mark.shell
+    @pytest.mark.windows
+    @pytest.mark.pew
+    def test_shell_nested_venv_in_project(self):
+        import subprocess
+        with temp_environ():
+            os.environ['PIPENV_VENV_IN_PROJECT'] = '1'
+            os.environ['PIPENV_IGNORE_VIRTUALENVS'] = '1'
+            with PipenvInstance() as p:
+                # Signal to pew to look in the project directory for the environment
+                os.environ['WORKON_HOME'] = p.path
+                c = p.pipenv('install requests')
+                assert c.return_code == 0
+                assert 'requests' in p.pipfile['packages']
+                assert 'requests' in p.lockfile['default']
+                # Check that .venv now shows in pew's managed list
+                pew_list = delegator.run('pew ls')
+                assert '.venv' in pew_list.out
+                # Check for the venv directory 
+                c = delegator.run('pew dir .venv')
+                # Compare pew's virtualenv path to what we expect
+                venv_path = get_windows_path(p.path, '.venv')
+                # os.path.normpath will normalize slashes
+                assert os.path.normpath(venv_path) == os.path.normpath(c.out.strip())
+                # Have pew run 'pip freeze' in the virtualenv
+                # This is functionally the same as spawning a subshell
+                # If we can do this we can theoretically amke a subshell
+                args = ['pew', 'in', '.venv', 'pip', 'freeze']
+                process = subprocess.Popen(
+                    args,
+                    shell=True, 
+                    universal_newlines=True, 
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE
+                )
+                out, _ = process.communicate()
+                assert any(req.startswith('requests') for req in out.splitlines()) is True
+
 
     @pytest.mark.run
     @pytest.mark.dotenv


### PR DESCRIPTION
* Allow PIPENV_IGNORE_VIRTUALENVS to work with pipenv shell
* Fixes #894