### PR TITLE
Move COPY . /app after pipenv install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,12 @@ WORKDIR /app
 
 # COPY Pipfile Pipfile
 # COPY Pipfile.lock Pipfile.lock
-# COPY . /app
 
 # -- Install dependencies:
 # RUN pipenv install --deploy --system
+
+# -- After installing requirements copy the rest of the code
+# COPY . /app
 
 ENTRYPOINT []
 CMD [ "/bin/bash" ]


### PR DESCRIPTION
When working with concrete projects and/or auto-builds, you won't want every push to require a full dependency pull, besides the network issue there is the timing issue.

You should rebuild the dependencies only if Pipfile / Pipfile.lock is changed.

P.S the new empty line was unintentional, added auto-magically by the Github online editor.