### PR TITLE
Document Nix installation option

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -220,6 +220,16 @@ To upgrade pipenv at any time::
 
 This will install both ``pipenv`` and ``pew`` (one of our dependencies) in an isolated virtualenv, so it doesn't interfere with the rest of your Python installation!
 
+.. _more_proper_installation:
+
+☤ Referentially Transparent Installation of Pipenv
+==================================================
+
+Nix provides atomic upgrades and rollbacks, it's reliable and reproducible thanks to keeping all dependencies isolated all the way down to libc.
+
+`Once installed <https://nixos.org/nix/>`_ simply run::
+
+    $ nix-env --install --attr pipenv
 
 .. _pragmatic_installation:
 


### PR DESCRIPTION
Hi, I just packaged pipenv in Nixpkgs:

https://github.com/NixOS/nixpkgs/commit/e55b99e840e713f840f4a6989211913707838708

At the moment it's only available in the unstable channel, but (even if you're not on the unstable channel) you can easily try it out (after installing Nix: `curl https://nixos.org/nix/install | sh` if you don't have it already) with:

    env NIX_PATH='nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/e55b99e840e713f840f4a6989211913707838708.tar.gz' nix-env -f '<nixpkgs>' --install --attr pipenv

or

    env NIX_PATH='nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-unstable.tar.gz' nix-env -f '<nixpkgs>' --install --attr pipenv

(the first tarball link is pinned to the specific commit at which pipenv appeared, the 2nd link instead will track the most recent unstable channel, but that means that the binary cache for it will be often not available)

Since this is very recent, the binary caches aren't there yet, which means it'll take a few hours (for Linux, or a few days for the Macos) prebuilt derivations to be available