### PR TITLE
Fix pip file deps conversion

### DIFF
--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -530,8 +530,8 @@ def convert_deps_from_pip(dep):
 
 
     # File installs.
-    if (req.uri or (os.path.exists(req.path) if req.path else False) or
-            os.path.exists(req.name)) and not req.vcs:
+    if (req.uri or (os.path.isfile(req.path) if req.path else False) or
+            os.path.isfile(req.name)) and not req.vcs:
         # Assign a package name to the file, last 7 of it's sha256 hex digest.
         if not req.uri and not req.path:
             req.path = os.path.abspath(req.name)

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -239,19 +239,7 @@ class TestPipenv:
         with PipenvInstance() as p:
             shutil.copy(source_path, os.path.join(p.path, file_name))
             os.mkdir(os.path.join(p.path, "tablib"))
-
             c = p.pipenv('install {}'.format(file_name))
-            key = [k for k in p.pipfile['packages'].keys()][0]
-            dep = p.pipfile['packages'][key]
-
-            assert 'file' in dep or 'path' in dep
-            assert c.return_code == 0
-
-            key = [k for k in p.lockfile['default'].keys()][0]
-            dep = p.lockfile['default'][key]
-
-            assert 'file' in dep or 'path' in dep
-
             c = p.pipenv('uninstall --all --verbose')
             assert c.return_code == 0
             assert 'tablib' in c.out


### PR DESCRIPTION
Fix for determining if a package name is a locally installed package.  I ran into this because a project I work on depends on the `ansible` Python package _and_ has a top-level `ansible/` directory which is _not_ a Python package.  

The current logic detects the `ansible/` filesystem directory as a Python package file installation and sets the package name to the hash of the directory path, which is nonsense.  Then, `pip` tries to uninstall something like `deadbeef` and fails, not uninstalling anything after that non-existent "package".

I kept this change simple and stupid as I believe that the file (un)installation support is really just about _files_, and I didn't want to drag `importlib` into this.

re: 

- https://github.com/kennethreitz/pipenv/pull/818
- https://github.com/kennethreitz/pipenv/pull/868