### PR TITLE
Fix is_file

### DIFF
--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -771,7 +771,7 @@ def is_file(package):
     if hasattr(package, 'keys'):
         return any(key for key in package.keys() if key in ['file', 'path'])
 
-    if os.path.exists(str(package)):
+    if os.path.isfile(str(package)):
         return True
 
     for start in FILE_LIST:

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -534,8 +534,8 @@ def convert_deps_from_pip(dep):
     extras = {'extras': req.extras}
 
     # File installs.
-    if (req.uri or (os.path.isfile(req.path) if req.path else False) or
-            os.path.isfile(req.name)) and not req.vcs:
+    if (req.uri or (is_file(req.path) if req.path else False) or
+        is_file(req.name)) and not req.vcs:
         # Assign a package name to the file, last 7 of it's sha256 hex digest.
         if not req.uri and not req.path:
             req.path = os.path.abspath(req.name)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,8 @@
 
 import os
 import pytest
+import shutil
+import tempfile
 from mock import patch, Mock
 
 import pipenv.utils
@@ -106,6 +108,25 @@ class TestUtils:
         with pytest.raises(ValueError) as e:
             dep = pipenv.utils.convert_deps_from_pip(dep)
             assert 'pipenv requires an #egg fragment for vcs' in str(e)
+
+    @pytest.mark.parametrize('entry, expected', [
+        ('http://example.com/package', True),
+        ('https://example.com/package', True),
+        ('ftp://example.com/package', True),
+        ('file:///tmp/package', True)
+    ])
+    def test_is_file(self, entry, expected):
+        pipenv.utils.is_file(entry) is expected
+
+    def test_is_file_files(self):
+        with tempfile.NamedTemporaryFile() as temp_file:
+            assert pipenv.utils.is_file(temp_file.name)
+
+        dir_name = tempfile.mkdtemp()
+        try:
+            assert pipenv.utils.is_file(dir_name) is False
+        finally:
+            shutil.rmtree(dir_name)
 
     @pytest.mark.parametrize('version, specified_ver, expected', [
         ('*', '*', True),


### PR DESCRIPTION
Related to #926, `utils.is_file` seems like it should check not only that a file exists but that a file is a file and not a directory.

I added some tests for `utils.is_file` but I don't have any pytest experience so please let me know if there's a better way to accomplish that logic.