### PR TITLE
Revert "Fix #973 Fails if two conflicting "requires" sections are present."

### DIFF
--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -227,14 +227,6 @@ class Project(object):
         with open(self.pipfile_location) as f:
             contents = f.read()
 
-        sections = re.findall("\[[a-zA-Z-]+\]", contents)
-        for section in set(sections):
-            section_count = sections.count(section)
-            if section_count > 1:
-                raise RuntimeError(
-                    "Your Pipfile contains section '{}' multiple times ({}x)".format(section, section_count)
-                )
-
         # If any outline tables are present...
         if ('[packages.' in contents) or ('[dev-packages.' in contents):
 

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,5 +1,4 @@
 import pipenv.project
-import pytest
 from pipenv.vendor import delegator
 
 
@@ -154,22 +153,3 @@ class TestProject():
         assert lockfile['_meta']['hash'] == {'sha256': 'ff0b0584610a7091156f32ca7d5adab8f29cb17263c6d63bcab42de2137c4787'}
 
         delegator.run('rm -fr test_internal_lockfile')
-
-    def test_duplicate_sections(self):
-        proj = pipenv.project.Project()
-
-        # Create test space.
-        delegator.run('mkdir test_duplicate_sections')
-
-        with open('test_duplicate_sections/Pipfile', 'w') as f:
-            f.write('[requires]\n'
-                    'python_version = "3.6"\n\n'
-                    '[requires]\n'
-                    'python_version = "2.7"\n')
-
-        proj._pipfile_location = 'test_duplicate_sections/Pipfile'
-
-        with pytest.raises(RuntimeError):
-            _ = proj.parsed_pipfile
-
-        delegator.run('rm -fr test_duplicate_sections')


### PR DESCRIPTION
Reverts kennethreitz/pipenv#976