### PR TITLE
fix pip index handling

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -241,7 +241,7 @@ def import_requirements(r=None, dev=False):
     indexes = []
     # Find and add extra indexes.
     for line in contents.split('\n'):
-        if line.startswith(('-i ', '--index ')):
+        if line.startswith(('-i ', '--index ', '--index-url ')):
             indexes.append(line.split()[1])
 
     reqs = [f for f in parse_requirements(r, session=pip._vendor.requests)]


### PR DESCRIPTION
Fix handling of the proper long index option (--index-url) for pip install.

As far as I can tell, `pip install` uses `-i` and `--index-url` (see [documentation](https://pip.readthedocs.io/en/stable/reference/pip_install/#cmdoption-index-url)), the `pip search` accepts `--index` long option. Those options are added by [pip-tools](https://github.com/jazzband/pip-tools) when using pip-compile.

I'm wondering if the packages should not be associated with that index, following https://docs.pipenv.org/advanced.html#specifying-package-indexes

Change mentioned in #856 

Example `requirements.txt` coming out of `pip-compile`:

```
--index-url https://pypi.example.com/xxx/+simple/
Django==1.9.5
myprivatepkg==1.1.5
```