### PR TITLE
Use the default PYENV_ROOT if it is not set

### DIFF
--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -81,9 +81,9 @@ PIPENV_INSTALL_TIMEOUT = 60 * 15
 
 PIPENV_DONT_USE_PYENV = os.environ.get('PIPENV_DONT_USE_PYENV')
 
-PYENV_ROOT = os.environ.get('PYENV_ROOT')
+PYENV_ROOT = os.environ.get('PYENV_ROOT', os.path.expanduser('~/.pyenv'))
 
-PYENV_INSTALLED = (bool(os.environ.get('PYENV_SHELL')) or bool(PYENV_ROOT))
+PYENV_INSTALLED = (bool(os.environ.get('PYENV_SHELL')) or bool(os.environ.get('PYENV_ROOT')))
 
 SESSION_IS_INTERACTIVE = bool(os.isatty(sys.stdout.fileno()))
 


### PR DESCRIPTION
When running `pipenv install`, it doesn't see that I have already installed the Python version through pyenv. I get the following warning:
```
Warning: PYENV_ROOT is not set. New python paths will probably not be exported
properly after installation.
```

If I run `PYENV_ROOT=~/.pyenv pipenv install` then it successfully sees the installed version.

I don't export a `PYENV_ROOT`, as pyenv defaults to using `~/.pyenv` (seen [here](https://github.com/pyenv/pyenv/blob/2f396596d768bf7aa300f7e89e89ae4cc0f748aa/libexec/pyenv#L54)).

This PR tells Pipenv to use this default if there's no `PYENV_ROOT` set, so that it doesn't break when used with the default installation of pyenv.