### PR TITLE
Dependency resolution - Do not pin candidates on first selection

### DIFF
--- a/pipenv/patched/pip/req/req_set.py
+++ b/pipenv/patched/pip/req/req_set.py
@@ -749,7 +749,7 @@ class RequirementSet(object):
         # print('\n')
         # print('\n')
 
-        return self.requirements.values() + more_reqs
+        return more_reqs
 
     def cleanup_files(self):
         """Clean up files, remove builds."""

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -843,6 +843,29 @@ requests = "*"
             c = p.pipenv('install')
             assert c.return_code == 0
 
+    @pytest.mark.extras
+    @pytest.mark.lock
+    @pytest.mark.requirements
+    @pytest.mark.complex
+    def test_complex_lock_deep_extras(self):
+        # records[pandas] requires tablib[pandas] which requires pandas.
+
+        with PipenvInstance() as p:
+            with open(p.pipfile_path, 'w') as f:
+                contents = """
+[packages]
+records = {extras = ["pandas"], version = "==0.5.2"}
+                """.strip()
+                f.write(contents)
+
+            c = p.pipenv('lock')
+            assert c.return_code == 0
+            assert 'tablib' in p.lockfile['default']
+            assert 'pandas' in p.lockfile['default']
+
+            c = p.pipenv('install')
+            assert c.return_code == 0
+
     @pytest.mark.lock
     @pytest.mark.deploy
     def test_deploy_works(self):

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -1,4 +1,5 @@
 import os
+from pkg_resources import parse_version
 import re
 import tempfile
 import shutil
@@ -816,6 +817,28 @@ maya = "*"
 
             c = p.pipenv('lock')
             assert c.return_code == 0
+
+            c = p.pipenv('install')
+            assert c.return_code == 0
+
+    @pytest.mark.lock
+    @pytest.mark.requirements
+    @pytest.mark.complex
+    def test_complex_lock_changing_candidate(self):
+        # The requests candidate will change from latest to <2.12.
+
+        with PipenvInstance() as p:
+            with open(p.pipfile_path, 'w') as f:
+                contents = """
+[packages]
+"docker-compose" = "==1.16.0"
+requests = "*"
+                """.strip()
+                f.write(contents)
+
+            c = p.pipenv('lock')
+            assert c.return_code == 0
+            assert parse_version(p.lockfile['default']['requests']['version'][2:]) < parse_version('2.12')
 
             c = p.pipenv('install')
             assert c.return_code == 0


### PR DESCRIPTION
Trying to address #875, #993, #1060

What this PR still needs:
- [x] A test to reproduce the issue where pre-pinning candidate causes the resolution to fail.
- [x] A test that covers what the initial patch from Kenneth intended to fix.

Details can be found on this comment: https://github.com/kennethreitz/pipenv/issues/875#issuecomment-337717817