### PR TITLE
Improvements to startup speed

### DIFF
--- a/pipenv/__init__.py
+++ b/pipenv/__init__.py
@@ -14,7 +14,6 @@ sys.path.insert(0, v_path)
 v_path = os.path.abspath(os.path.sep.join([os.path.dirname(os.path.realpath(__file__)), 'patched']))
 sys.path.insert(0, v_path)
 
-from .cli import cli
-
 if __name__ == '__main__':
+    from .cli import cli
     cli()

--- a/pipenv/__main__.py
+++ b/pipenv/__main__.py
@@ -1,4 +1,10 @@
-from .cli import cli
+import os
 
 if __name__ == '__main__':
-    cli()
+    pipenv_complete = os.environ.get("_PIPENV_COMPLETE")
+    if pipenv_complete:
+        import click_completion
+        click_completion._shellcomplete(None, "pipenv")
+    else:
+        from .cli import cli
+        cli()


### PR DESCRIPTION
See issue #953.

The main issue with slow startup times seems to be that `from .cli import cli` takes quite long, this commit moves these imports to conditional blocks so they're run as late as possible, and not at all if not needed.

I can understand if this "fix" feels too hacky, but I don't know what exactly might be the root cause of the slow startup problems. Once the root cause is found and fixed, it would be great to add some kind of a regression test for it so it doesn't happen again.