### PR TITLE
Fixed the remark about the best shell.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,7 +110,7 @@ Alternatively, with bash, put this in your ``.bashrc`` or ``.bash_profile``::
 
 Magic shell completions are now enabled! There is also a `fish plugin <https://github.com/fisherman/pipenv>`_, which will automatically activate your subshells for you!
 
-Fish is the best shell. You should use it.
+ZSH is the best shell. You should use it.
 
 ☤ Usage
 -------


### PR DESCRIPTION
Was a little misinformation in the doc. Couldn't let it slide.

_ok, so fish really is the best shell in terms of sanity, except for the fact that it breaks anything that relies on POSIX compat. Also, doesn't doesn't do escape sequences correctly with rsync or sftp, which ZSH does. I'd actually be using it if it did that one thing. ZSH also has a lot of the same benefits for scripting; i.e. arrays have normal-looking syntax for index operations, you don't need to do the special `"${myvar[@]}"` incantation to iterate on them, don't have to quote every effing variable to keep it from splitting on whitespace, recursive globbing (and every other kind of globbing), etc. It's like Fish, but more mature and will run most POSIX shell scripts. Everything the heart wants._