### PR TITLE
Fix #1085 for Python 2

### DIFF
--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -1060,7 +1060,7 @@ def touch_update_stamp():
     mkdir_p(PIPENV_CACHE_DIR)
     p = os.sep.join((PIPENV_CACHE_DIR, '.pipenv_update_check'))
     try:
-        os.utime(p)
-    except FileNotFoundError:
+        os.utime(p, None)
+    except OSError:
         with open(p, 'w') as fh:
             fh.write('')


### PR DESCRIPTION
This is needed to get pipenv to work on Python 2 hosts (current version on PyPI is broken). Adds the base class of `FileNotFoundError` and adds the default argument of `None` to the `utime` call.