### PR TITLE
Use the pipenv cache path in the patched pip-tools

### DIFF
--- a/pipenv/patched/README.md
+++ b/pipenv/patched/README.md
@@ -5,6 +5,7 @@
 - Pip is modified, to make it resolve deep extras links.
 - Pip-tools is modified, to make it resolve markers.
 - Pip-tools is modified, to make it do 12 rounds instead of 10, by default.
+- Pip-tools is modified, to use its own cache path with dependency resolution, and not conflict with the "real" pip-tools.
 - Crayons is upgraded.
 - Safety is hacked together to always work on any system.
 - TOML libraries are upgraded to... work.

--- a/pipenv/patched/piptools/locations.py
+++ b/pipenv/patched/piptools/locations.py
@@ -2,10 +2,13 @@ import os
 from shutil import rmtree
 
 from .click import secho
-from pip.utils.appdirs import user_cache_dir
+# Patch by vphilippon 2017-11-22: Use pipenv cache path.
+# from pip.utils.appdirs import user_cache_dir
+from pipenv.environments import PIPENV_CACHE_DIR
 
 # The user_cache_dir helper comes straight from pip itself
-CACHE_DIR = user_cache_dir('pip-tools')
+# CACHE_DIR = user_cache_dir(os.path.join('pip-tools'))
+CACHE_DIR = PIPENV_CACHE_DIR
 
 # NOTE
 # We used to store the cache dir under ~/.pip-tools, which is not the


### PR DESCRIPTION
This will avoid having `pipenv` and the "real" `pip-tools` stepping on each other.

I encountered some issues while working on both projects due to that overlap, so lets fix this.