### PR TITLE
Only strip VCS prefix for URIs with vcs+ patterns

### DIFF
--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -45,7 +45,7 @@ specifiers = [k for k in lookup.keys()]
 
 # List of version control systems we support.
 VCS_LIST = ('git', 'svn', 'hg', 'bzr')
-SCHEME_LIST = ('http://', 'https://', 'ftp://', 'file://', 'git://')
+SCHEME_LIST = ('http://', 'https://', 'ftp://', 'file://')
 
 requests = requests.Session()
 
@@ -661,10 +661,10 @@ def convert_deps_from_pip(dep):
             req.path = None
 
         # Crop off the git+, etc part.
-        if '+' in req.uri:
+        if req.uri.startswith('{0}+'.format(req.vcs)):
             req.uri = req.uri[len(req.vcs) + 1:]
         dependency.setdefault(req.name, {}).update({req.vcs: req.uri})
-        print('dependency: {}'.format(dependency))
+
         # Add --editable, if it's there.
         if req.editable:
             dependency[req.name].update({'editable': True})

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -45,7 +45,7 @@ specifiers = [k for k in lookup.keys()]
 
 # List of version control systems we support.
 VCS_LIST = ('git', 'svn', 'hg', 'bzr')
-SCHEME_LIST = ('http://', 'https://', 'ftp://', 'file://')
+SCHEME_LIST = ('http://', 'https://', 'ftp://', 'file://', 'git://')
 
 requests = requests.Session()
 
@@ -661,8 +661,10 @@ def convert_deps_from_pip(dep):
             req.path = None
 
         # Crop off the git+, etc part.
-        dependency.setdefault(req.name, {}).update({req.vcs: req.uri[len(req.vcs) + 1:]})
-
+        if '+' in req.uri:
+            req.uri = req.uri[len(req.vcs) + 1:]
+        dependency.setdefault(req.name, {}).update({req.vcs: req.uri})
+        print('dependency: {}'.format(dependency))
         # Add --editable, if it's there.
         if req.editable:
             dependency[req.name].update({'editable': True})

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -537,6 +537,19 @@ requests = {version = "*", os_name = "== 'splashwear'"}
             c = p.pipenv('run python -c "import requests;"')
             assert c.return_code == 1
 
+    @pytest.mark.install
+    @pytest.mark.vcs
+    @pytest.mark.tablib
+    def test_install_editable_git_tag(self):
+        with PipenvInstance() as p:
+            c = p.pipenv('install -e git+git://github.com/kennethreitz/tablib.git@v0.12.1#egg=tablib')
+            assert c.return_code == 0
+            assert 'tablib' in p.pipfile['packages']
+            assert 'tablib' in p.lockfile['default']
+            assert 'git' in p.lockfile['default']['tablib']
+            assert p.lockfile['default']['tablib']['git'] == 'git://github.com/kennethreitz/tablib.git'
+            assert 'ref' in p.lockfile['default']['tablib']            
+
     @pytest.mark.run
     @pytest.mark.alt
     @pytest.mark.install


### PR DESCRIPTION
- Fixes #1126
- Does a simple check before stripping the VCS prefix on
a `requirement.uri` in `pipenv.utils.convert_deps_from_pip`