### PR TITLE
Correct broken link to official python documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ Pipenv: Python Dev Workflow for Humans
 
 ---------------
 
-**Pipenv** — the officially recommended Python packaging tool from `Python.org <https://packaging.python.org/new-tutorials/installing-and-using-packages/>`_, free (as in freedom).
+**Pipenv** — the officially recommended Python packaging tool from `Python.org <https://packaging.python.org/tutorials/managing-dependencies/#managing-dependencies>`_, free (as in freedom).
 
 Pipenv is a tool that aims to bring the best of all packaging worlds (bundler, composer, npm, cargo, yarn, etc.) to the Python world. *Windows is a first–class citizen, in our world.*
 


### PR DESCRIPTION
Fixes https://github.com/kennethreitz/pipenv/issues/1140

> Minor thing, but the link on the homepage of the docs that ties Pipenv into the packaging ecosystem is currently returning 404: the tutorial got moved to: https://packaging.python.org/tutorials/managing-dependencies/#managing-dependencies